### PR TITLE
Ejecución de builtins en el padre

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+LSAN_OPTIONS=verbosity=1:log_threads=1

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,7 @@
                     "ignoreFailures": true
                 }
             ],
+            "envFile": "${workspaceFolder}/.env",
             "preLaunchTask": "minishellBuildToDebug",
             "miDebuggerPath": "/usr/bin/gdb"
         }

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ CFLAGS_DEBUG		= ${CFLAGS} -g -fsanitize=address
 OBJS				= ${SRCS:.c=.o}
 NAME				= minishell
 
+CC					= clang
 # 
 # Variables para compilado de tests (unitarios y de integración)
 #

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -49,21 +49,26 @@ static void		execute_command_read(abs_struct *base)
 int main(int argc, char **argv, char **envp)
 {
 	int         minishell_ready;
-	abs_struct  base;
+	abs_struct  *base;
 
+	if (!(base = ft_calloc(1, sizeof(abs_struct))))
+		ft_exit_minishell(0, 1);
 	(void)argc;
 	(void)argv;
-	minishell_ready = ft_init_minishell(&base, envp);
+	minishell_ready = ft_init_minishell(base, envp);
 	if (minishell_ready)
 		clearScreen();
 	while (minishell_ready)
 	{
-		ft_show_prompt(&base);
-		obtain_full_line(&base);
-		execute_command_read(&base);
-		base.first_job = 0;
-		base.num_args = 0;
-		base.parseString = 0;
+		ft_putstr(base->env[base->lines_envp - 1]);
+		ft_putstr("\n");
+		ft_show_prompt(base);
+		obtain_full_line(base);
+		execute_command_read(base);
+		base->first_job = 0;
+		base->num_args = 0;
+		base->parseString = 0;
 	}
+	free(base);
 	return (0);
 }

--- a/srcs/setenv.c
+++ b/srcs/setenv.c
@@ -110,6 +110,6 @@ int			ft_setenv(abs_struct *base, t_process *p)
 		return (ret);
     }
     ft_putstr("\e[0mError en los argumentos\n");
-	base->error = 0;
+	base->error = 0;	
     return (0);
 }

--- a/utils/ft_launch_job.c
+++ b/utils/ft_launch_job.c
@@ -21,8 +21,6 @@ static void		ft_fork_child(abs_struct *base, t_process *p, t_files_fd fds)
 {
 	pid_t		pid;
 
-	if (p->argv && !ft_strcmp(*p->argv, "exit"))
-		ft_exit_minishell(base, 0);
 	/* Fork the child processes.  */
 	pid = fork();
 	//pid = 0;
@@ -43,7 +41,6 @@ static void		ft_fork_child(abs_struct *base, t_process *p, t_files_fd fds)
 		p->pid = pid;
 		wait(&p->status);
 		p->status /= 256;
-
 	}
 }
 
@@ -64,6 +61,12 @@ static void		ft_launch_processes(abs_struct *base, t_job *j)
 	fds.infile = j->stdin;
 	for (p = j->first_process; p; p = p->next)
 	{
+		if (ft_execute_builtin(base, p))
+		{
+			p->completed = 1;
+			p->status = 0;
+			continue ;
+		}
 		ft_setup_pipes(base, j, p, &fds);
 		ft_fork_child(base, p, fds);
 		ft_cleanup_fds(j, fds);

--- a/utils/ft_launch_process.c
+++ b/utils/ft_launch_process.c
@@ -92,16 +92,12 @@ static void		prepare_process(t_process *p, t_files_fd files_fd)
 	}
 }
 
+
 void            ft_launch_process(abs_struct *base, t_process *p,
 	t_files_fd files_fd)
 {
 	prepare_process(p, files_fd);
-	if (ft_execute_builtin(base, p))
-	{
-		p->completed = 1;
-		p->status = 0;
-	}
-	else if (*p->argv[0] == '/')
+	if (*p->argv[0] == '/')
 		ft_execute_absolute_shell_command(base, p);
 	else if (*p->argv[0] == '.')
 		ft_execute_relative_shell_command(base, p);


### PR DESCRIPTION
Los builtins dado que van a modificar los datos que tienen que estar accesibles para todos los procesos, se tiene que ejecutar desde el hijo principal, ya que al hacer fork no podemos establecer una zona de memoria compartida donde podríamos modificar punteros que estén siendo utilizados por ambos procesos (al menos, y no he encontrado la manera)