### PR TITLE
Redirecciones y errores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ history.txt
 utils/main
 pipes
 redirection_redirected_output
+a.out

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ UTILS 				= utils/ft_putnbr.c utils/ft_putstr.c utils/ft_split.c \
 	utils/ft_build_processes.c utils/ft_build_process.c utils/ft_trim.c \
 	utils/ft_split_shell.c utils/ft_release_process.c utils/ft_array_add.c \
 	utils/redirections.c utils/ft_array_slide_left.c \
-	utils/ft_set_default_signals.c utils/ft_isinteger.c utils/std_fds.c	
+	utils/ft_set_default_signals.c utils/ft_isinteger.c utils/std_fds.c	\
+	utils/ft_extract_redirections_from_argv.c
 
 SRCS_WITHOUT_MAIN	=  srcs/ft_exit_minishell.c srcs/clearScreen.c \
 	srcs/ft_execute_ctrl_d.c srcs/echo.c srcs/cd.c \

--- a/minishell.h
+++ b/minishell.h
@@ -124,7 +124,7 @@ t_process		*ft_build_process(char *expanded_cmd);
 int				set_redirections(abs_struct *base, t_process *p);
 
 void			ft_launch_job(abs_struct *base, t_job *j);
-void            ft_launch_process(abs_struct *base, t_process *p, t_files_fd files_fd);
+void            ft_launch_process(abs_struct *base, t_process *previous, t_process *current);
 int         	ft_execute_builtin(abs_struct *base, t_process *p);
 
 
@@ -134,7 +134,7 @@ t_process		*ft_release_process(t_process *p);
 int				ft_set_default_signals();
 void			forked_process_signal_handler(int sig);
 void			dup_std_fds(t_files_fd *fds);
-void			restore_std_fds(t_files_fd fds);
+void			restore_std_fds(t_files_fd *fds);
 
 size_t			ft_strlcat(char *dst, const char *src, size_t size);
 char			*ft_strlcat_paths(char *prefix_path, const char *relative_path);

--- a/minishell.h
+++ b/minishell.h
@@ -32,7 +32,6 @@ typedef struct s_files_fd
 	int infile;
     int outfile;
 	int errfile;
-	int pipes[2];
 }				t_files_fd;
 
 /* A process is a single process.  */
@@ -45,7 +44,7 @@ typedef struct s_process
   char				completed;             /* true if process has completed */
   char				stopped;               /* true if process has stopped */
   int				status;                 /* reported status value */
-  t_files_fd		std_fds;
+  int				pipe[2];
 } t_process;
 
 
@@ -135,6 +134,7 @@ int				ft_set_default_signals();
 void			forked_process_signal_handler(int sig);
 void			dup_std_fds(t_files_fd *fds);
 void			restore_std_fds(t_files_fd *fds);
+int				ft_extract_redirections_from_argv(t_process *p);
 
 size_t			ft_strlcat(char *dst, const char *src, size_t size);
 char			*ft_strlcat_paths(char *prefix_path, const char *relative_path);

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -36,16 +36,13 @@ int obtain_full_line(abs_struct *base)
 static void		execute_command_read(abs_struct *base)
 {
 	t_job		*job;
-	t_files_fd	std_fds;
 
-	dup_std_fds(&std_fds);
 	job = ft_build_jobs(base->string);
 	while (job) {
 		base->first_job = job;
 		ft_launch_job(base, job);
 		job = ft_release_job(job);
 	}
-	restore_std_fds(std_fds);
 }
 
 int main(int argc, char **argv, char **envp)

--- a/to_do.txt
+++ b/to_do.txt
@@ -1,16 +1,17 @@
-5. Implementación de redirecciones. ("<", ">", ">>")
-    * He dejado 2 TODOS:
-    ** ft_launch_process.c:ft_execute_absolute_shell_command -> Eliminar de los argumentos que se reciben, las redirecciones que están en p->argv
-    ** ft_launch_process.c:prepare_process -> Hacer los dups correspondientes en base a las redirecciones que están en p->argv
 6.Comprobar/introducir el correcto funcionamiento de las variables de entorno
 9. Mejoras si es posible en la estructura basica del codigo en caso de que la lógica general fallara
 10. Empezar a solucionar leaks:  compilar con flag -fsanitize=address para anotar los leaks que puedan salir al desarrollar
 11. $? funciona pero...¿igual deberia ir diferente?
 15. ¿Textos en inglés?
 18. Expandir ~ en el export. Por ejemplo: export HOME=~/42 en mi caso el ~ se tiene que expandir al valor actual de HOME que inicialmente es /home/visv
-19. Tenemos que controlar que si pulsamos enter cuando están las comillas abiertas, nos siga pidiendo datos de entrada hasta llegar a las comillas?
-20. Tratar la \ en el cd? En bash una barra invertida se interpreta como un salto de línea para concatenar líneas
-21. Tratar los caracteres de borrado. Si escribimos un comando, borramos para corregir y reescribimos, ..., nosotros lo que ejecutaremos no es el resultado que ve el usuario por pantalla sino todo el comando entero escrito incluyendo los caracteres de borrado, ...
-22. Tratar las comillas en los comandos?
-24. Ctrl + d ha dejado de funcionar. Seguramente esté ejecutando el exit dentro del fork y entonces mata al hijo y no al minishell
+* Esta parte se debe quedar corregida en la función ft_expand_cmd
+21. Tratar los caracteres de borrado. Si escribimos un comando, borramos para corregir y reescribimos, ..., nosotros lo que ejecutaremos no es el result.ado que ve el usuario por pantalla sino todo el comando entero escrito incluyendo los caracteres de borrado, ...
+22. Tratar las comillas en los comandos.
+* En el punto 18 muestra dónde está el punto común donde se procesa
+* Como función útil para implementar esto, tenemos la función ft_split_shell_by. Igual que el split pero teniendo en cuenta las comillas
+    Por ejemplo: "hola>mundo">42
+    Partido por: >
+    Nos da 2 tokens:
+    * "hola>mundo"
+    * 42
 25. Al lanzar el comando: cat author | more (si el archivo pagina), y pulsamos Ctrl + c, nos finaliza la ejecución de minishell

--- a/utils/ft_build_process.c
+++ b/utils/ft_build_process.c
@@ -30,9 +30,6 @@ t_process			*ft_build_process(char *expanded_cmd)
 
 	if (!(proc = ft_calloc(1, sizeof(t_process))))
 		return (0);
-	proc->std_fds.infile = STDIN_FILENO;
-	proc->std_fds.outfile = STDOUT_FILENO;
-	proc->std_fds.errfile = STDERR_FILENO;
 	fields = ft_extract_fields(expanded_cmd, &proc->argv);
 	if (fields < 0)
 	{

--- a/utils/ft_extract_redirections_from_argv.c
+++ b/utils/ft_extract_redirections_from_argv.c
@@ -1,0 +1,43 @@
+#include "minishell.h"
+
+static int	contains_redir(char *str)
+{
+	int		redir;
+	char	*tmp;
+	char	*argv;
+
+	argv = str;
+	tmp = 0;
+	redir = (((tmp = ft_split_shell_by(&argv, ">")) &&
+		*(argv - 1) == '>') ? 1 : 0);
+	if (tmp)
+		free(tmp);
+	if (redir)
+		return (redir);
+	argv = str;
+	redir = (((tmp = ft_split_shell_by(&argv, "<")) &&
+		*(argv - 1) == '<') ? 1 : 0);
+	if (tmp)
+		free(tmp);
+	return (redir);
+}
+
+int			ft_extract_redirections_from_argv(t_process *p)
+{
+	char	**i;
+	int		redirs_len;
+
+	i = p->argv;
+	redirs_len = 0;
+	while (*i)
+	{
+		if (!contains_redir(*i))
+			i++;
+		else
+		{
+			ft_array_add(&p->redirs, &redirs_len,  *i);
+			ft_array_slide_left(i);
+		}
+	}
+	return (1);
+}

--- a/utils/ft_launch_job.c
+++ b/utils/ft_launch_job.c
@@ -1,20 +1,24 @@
 #include "minishell.h"
 
-static void		ft_setup_pipes(abs_struct *base, t_job *j, t_process *p, t_files_fd *fds)
+static void		ft_init_current_io(abs_struct *base, t_process *current)
 {
-	if (p->next)
+	current->std_fds.infile = STDIN_FILENO;
+	current->std_fds.outfile = STDOUT_FILENO;
+	current->std_fds.errfile = STDERR_FILENO;
+	if (current->next)
 	{
-		/* Set up pipes */
-		if (pipe(fds->pipes) < 0)
-			ft_exit_minishell(base, 1);
-		fds->outfile = fds->pipes[1];
+		if (pipe(current->std_fds.pipes) < 0)
+			ft_exit_minishell(base, errno);
 	}
 	else
-		fds->outfile = j->std_fds.outfile;
-	fds->errfile = j->std_fds.errfile;
+	{
+		current->std_fds.pipes[0] = -1;
+		current->std_fds.pipes[1] = -1;
+	}
 }
 
-static void		ft_fork_child(abs_struct *base, t_process *p, t_files_fd fds)
+static void		ft_fork_child(abs_struct *base, t_process *previous,
+	t_process *current)
 {
 	pid_t		pid;
 
@@ -24,56 +28,42 @@ static void		ft_fork_child(abs_struct *base, t_process *p, t_files_fd fds)
 	//pid = 0;
 	if (pid == 0)
 	{
-		ft_launch_process(base, p, fds);
-		exit(p->status);
+		ft_launch_process(base, previous, current);
+		exit(current->status);
 	}
 	else if (pid < 0)
 		ft_exit_minishell(base, 1);
 	else
 	{
-		p->pid = pid;
-		wait(&p->status);
-		p->status /= 256;
-	}
-}
-
-static void		ft_cleanup_fds(t_files_fd fds)
-{
-	if (fds.infile > -1 && fds.infile != STDIN_FILENO)
-	{
-		close(fds.infile);
-	}
-	if (fds.outfile > -1 && fds.outfile != STDOUT_FILENO)
-	{
-		ft_putstr("Closing outfile:");
-		char *out = ft_itoa(fds.outfile);
-		ft_putstr(out);
-		ft_putstr("\n");
-		free(out);
-		close(fds.outfile);
+		current->pid = pid;
+		wait(&current->status);
+		current->status /= 256;
 	}
 }
 
 void			ft_launch_job(abs_struct *base, t_job *j)
 {
-	t_process	*p;
-	t_files_fd	fds;
-	t_files_fd	std_fds;
+	t_process	*current;
+	t_process	*previous;
+	
 
-	dup_std_fds(&std_fds);
-	fds.infile = j->std_fds.infile;
-	for (p = j->first_process; p; p = p->next)
+	dup_std_fds(&j->std_fds);
+	previous = 0;
+	for (current = j->first_process; current; current = current->next)
 	{
-		if (ft_execute_builtin(base, p))
+		if (ft_execute_builtin(base, current))
 		{
-			p->completed = 1;
-			p->status = 0;
+			current->completed = 1;
+			current->status = 0;
 			continue ;
 		}
-		ft_setup_pipes(base, j, p, &fds);
-		ft_fork_child(base, p, fds);
-		ft_cleanup_fds(fds);
-		fds.infile = fds.pipes[0];
+		ft_init_current_io(base, current);
+		ft_fork_child(base, previous, current);
+		if (previous && previous->std_fds.pipes[1] > -1)
+			close(previous->std_fds.pipes[1]);
+		if (current->next && current->std_fds.pipes[0] > -1)
+			close(current->std_fds.pipes[0]);
+		previous = current;
 	}
-	restore_std_fds(std_fds);
+	restore_std_fds(&j->std_fds);
 }

--- a/utils/ft_launch_process.c
+++ b/utils/ft_launch_process.c
@@ -66,13 +66,12 @@ static int		ft_set_std_fds(abs_struct *base, t_process *previous,
 	// TODO: Tratar los errores de dup2
 	if ((ret = set_redirections(base, current)))
 		return (ret);
-	if (previous && previous->std_fds.pipes[0] > -1)
-		dup2(previous->std_fds.pipes[0], STDIN_FILENO);
-	if (current->std_fds.pipes[1] > -1)
-		dup2(previous->std_fds.pipes[1], STDOUT_FILENO);
+	if (previous && previous->pipe[STDIN_FILENO] > -1)
+		dup2(previous->pipe[STDIN_FILENO], STDIN_FILENO);
+	if (current->pipe[STDOUT_FILENO] > -1)
+		dup2(current->pipe[STDOUT_FILENO], STDOUT_FILENO);
 	return (0);
 }
-
 
 void            ft_launch_process(abs_struct *base, t_process *previous,
 	t_process *current)

--- a/utils/redirections.c
+++ b/utils/redirections.c
@@ -80,45 +80,76 @@ static int	apply_output_add_redirection(char *fd, char *right_side)
 	return (0);
 }
 
-static int	apply_input_redirection(char *fd, char *right_side)
+static int	apply_input_redirection(abs_struct *base, char *fd, char *right_side)
 {
-	(void)fd;
-	(void)right_side;
-	
+	int		i_fd;
+	int		o_fd;
+	int		empty;
+	char	*fd_file;
+
+	empty = 0;
+	if (!ft_isinteger(fd) && !(empty = ft_isempty(fd)))
+		return (0);
+	i_fd = empty ? STDIN_FILENO : ft_atoi(fd);
+	if (!(fd_file = ft_trim(right_side)))
+		return (1);
+	if (!ft_strncmp(fd_file, "&-", 2))
+	{
+		free(fd_file);
+		// TODO: Comprobar si el fd está abierto como entrada, sino dar error (stat)
+		return (close(i_fd));
+	}
+	if ((o_fd = open((fd_file + (*fd_file == '&' ? 1 : 0)), O_RDONLY)) < 0)
+		ft_exit_minishell(base, errno);
+	if (dup2(o_fd, i_fd) < 0)
+		ft_exit_minishell(base, errno);	
+	if (*fd_file != '&')
+		close(o_fd);
+	free(fd_file);
 	return (0);
+}
+
+static int	set_redirection(abs_struct *base, char *i)
+{
+	char	*redir;
+	char	*fd;
+	int		redirected;
+
+	fd = 0;
+	redirected = 0;
+	if ((redir = i) && (fd = ft_split_shell_by(&redir, ">>")) &&
+		*(redir - 1) == '>')
+		redirected = apply_output_add_redirection(fd, redir);
+	if (fd)
+		free(fd);
+	fd = 0;
+	if (!redirected && (redir = i) &&
+		(fd = ft_split_shell_by(&redir, ">")) && *(redir - 1) == '>')
+		redirected = apply_output_redirection(base, fd, redir);
+	if (fd)
+		free(fd);
+	fd = 0;
+	if (!redirected && (redir = i) &&
+		(fd = ft_split_shell_by(&redir, "<")) && *(redir - 1) == '<')
+		redirected = apply_input_redirection(base, fd, redir);
+	if (fd)
+		free(fd);
+	return (redirected);
 }
 
 int			set_redirections(abs_struct *base, t_process *p)
 {
 	char	**i;
-	char	*fd;
-	char	*redir;
 	int		redirected;
 
 	if (!p || !p->argv || !extract_redirections_from_argv(p))
 		return (1);
 	i = p->redirs;
-	fd = 0;
 	redirected = 0;
 	while (!redirected && i && *i)
 	{
-		if ((redir = *i) && (fd = ft_split_shell_by(&redir, ">>")) &&
-			*(redir - 1) == '>')
-			redirected = apply_output_add_redirection(fd, redir);
-		if (fd)
-			free(fd);
-		fd = 0;
-		if (!redirected && (redir = *i) &&
-			(fd = ft_split_shell_by(&redir, ">")) && *(redir - 1) == '>')
-			redirected = apply_output_redirection(base, fd, redir);
-		if (fd)
-			free(fd);
-		fd = 0;
-		if (!redirected && (redir = *i) &&
-			(fd = ft_split_shell_by(&redir, "<")) && *(redir - 1) == '<')
-			redirected = apply_input_redirection(fd, redir);
-		if (fd)
-			free(fd);
+		if ((redirected = set_redirection(base, *i)))
+			return (redirected);
 		i++;
 	}
 	return (redirected);

--- a/utils/redirections.c
+++ b/utils/redirections.c
@@ -1,48 +1,7 @@
 #include "minishell.h"
 
-static int	contains_redir(char *str)
-{
-	int		redir;
-	char	*tmp;
-	char	*argv;
-
-	argv = str;
-	tmp = 0;
-	redir = (((tmp = ft_split_shell_by(&argv, ">")) &&
-		*(argv - 1) == '>') ? 1 : 0);
-	if (tmp)
-		free(tmp);
-	if (redir)
-		return (redir);
-	argv = str;
-	redir = (((tmp = ft_split_shell_by(&argv, "<")) &&
-		*(argv - 1) == '<') ? 1 : 0);
-	if (tmp)
-		free(tmp);
-	return (redir);
-}
-
-static int	extract_redirections_from_argv(t_process *p)
-{
-	char	**i;
-	int		redirs_len;
-
-	i = p->argv;
-	redirs_len = 0;
-	while (*i)
-	{
-		if (!contains_redir(*i))
-			i++;
-		else
-		{
-			ft_array_add(&p->redirs, &redirs_len,  *i);
-			ft_array_slide_left(i);
-		}
-	}
-	return (1);
-}
-
-static int	apply_output_redirection(abs_struct *base, char *fd, char *right_side)
+static int	apply_output_redirection(abs_struct *base, char *fd,
+	char *right_side)
 {
 	int		i_fd;
 	int		o_fd;
@@ -72,11 +31,34 @@ static int	apply_output_redirection(abs_struct *base, char *fd, char *right_side
 	return (0);
 }
 
-static int	apply_output_add_redirection(char *fd, char *right_side)
+static int	apply_output_add_redirection(abs_struct *base, char *fd,
+	char *right_side)
 {
-	(void)fd;
-	(void)right_side;
-	
+	int		i_fd;
+	int		o_fd;
+	int		empty;
+	char	*fd_file;
+
+	empty = 0;
+	if (!ft_isinteger(fd) && !(empty = ft_isempty(fd)))
+		return (0);
+	i_fd = empty ? STDOUT_FILENO : ft_atoi(fd);
+	if (!(fd_file = ft_trim(right_side)))
+		return (1);
+	if (!ft_strncmp(fd_file, "&-", 2))
+	{
+		free(fd_file);
+		// TODO: Comprobar si el fd está abierto como entrada, sino dar error (stat)
+		return (close(i_fd));
+	}
+	if ((o_fd = open((fd_file + (*fd_file == '&' ? 1 : 0)),
+		O_APPEND | O_RDWR | O_CREAT, 0666)) < 0)
+		ft_exit_minishell(base, errno);
+	if (dup2(o_fd, i_fd) < 0)
+		ft_exit_minishell(base, errno);	
+	if (*fd_file != '&')
+		close(o_fd);
+	free(fd_file);
 	return (0);
 }
 
@@ -119,17 +101,17 @@ static int	set_redirection(abs_struct *base, char *i)
 	redirected = 0;
 	if ((redir = i) && (fd = ft_split_shell_by(&redir, ">>")) &&
 		*(redir - 1) == '>')
-		redirected = apply_output_add_redirection(fd, redir);
+		redirected = apply_output_add_redirection(base, fd, redir);
 	if (fd)
 		free(fd);
 	fd = 0;
-	if (!redirected && (redir = i) &&
+	if (redirected && (redir = i) &&
 		(fd = ft_split_shell_by(&redir, ">")) && *(redir - 1) == '>')
 		redirected = apply_output_redirection(base, fd, redir);
 	if (fd)
 		free(fd);
 	fd = 0;
-	if (!redirected && (redir = i) &&
+	if (redirected && (redir = i) &&
 		(fd = ft_split_shell_by(&redir, "<")) && *(redir - 1) == '<')
 		redirected = apply_input_redirection(base, fd, redir);
 	if (fd)
@@ -142,7 +124,7 @@ int			set_redirections(abs_struct *base, t_process *p)
 	char	**i;
 	int		redirected;
 
-	if (!p || !p->argv || !extract_redirections_from_argv(p))
+	if (!p || !p->argv || !ft_extract_redirections_from_argv(p))
 		return (1);
 	i = p->redirs;
 	redirected = 0;

--- a/utils/redirections.c
+++ b/utils/redirections.c
@@ -42,38 +42,33 @@ static int	extract_redirections_from_argv(t_process *p)
 	return (1);
 }
 
-static int	apply_output_redirection(abs_struct *base, char *fd, char *right_side, t_process *p)
+static int	apply_output_redirection(abs_struct *base, char *fd, char *right_side)
 {
 	int		i_fd;
 	int		o_fd;
 	int		empty;
-	char	*abs_path;
+	char	*fd_file;
 
 	empty = 0;
 	if (!ft_isinteger(fd) && !(empty = ft_isempty(fd)))
 		return (0);
 	i_fd = empty ? STDOUT_FILENO : ft_atoi(fd);
-	if (!ft_strncmp(right_side, "&-", 2))
+	if (!(fd_file = ft_trim(right_side)))
+		return (1);
+	if (!ft_strncmp(fd_file, "&-", 2))
 	{
+		free(fd_file);
 		// TODO: Comprobar si el fd está abierto como salida, sino dar error (stat)
 		return (close(i_fd));
 	}
-	if (i_fd == STDOUT_FILENO)
-		p->std_fds.outfile = dup(STDOUT_FILENO);
-	if (!(abs_path = ft_get_absolute_path(base, right_side)))
-		return (1);
-	if ((o_fd = open(abs_path, O_CREAT | O_TRUNC | O_WRONLY, 0666)) < 0 ||
-		dup2(o_fd, i_fd) < 0)
-	{
-		free(abs_path);
-		if (o_fd > -1)
-			close(o_fd);
-		ft_putstr_fd(strerror(errno), STDERR_FILENO);
-		return (errno);
-	}
-	free(abs_path);
-	if (*right_side != '&')
+	if ((o_fd = open((fd_file + (*fd_file == '&' ? 1 : 0)),
+		O_CREAT | O_TRUNC | O_WRONLY, 0666)) < 0)
+		ft_exit_minishell(base, errno);
+	if (dup2(o_fd, i_fd) < 0)
+		ft_exit_minishell(base, errno);	
+	if (*fd_file != '&')
 		close(o_fd);
+	free(fd_file);
 	return (0);
 }
 
@@ -115,7 +110,7 @@ int			set_redirections(abs_struct *base, t_process *p)
 		fd = 0;
 		if (!redirected && (redir = *i) &&
 			(fd = ft_split_shell_by(&redir, ">")) && *(redir - 1) == '>')
-			redirected = apply_output_redirection(base, fd, redir, p);
+			redirected = apply_output_redirection(base, fd, redir);
 		if (fd)
 			free(fd);
 		fd = 0;

--- a/utils/std_fds.c
+++ b/utils/std_fds.c
@@ -7,18 +7,21 @@ void			dup_std_fds(t_files_fd *fds)
 	fds->errfile = dup(STDERR_FILENO);
 }
 
-void			restore_std_fds(t_files_fd fds)
+void			restore_std_fds(t_files_fd *fds)
 {
-	if (fds.infile > -1 && fds.infile != STDIN_FILENO)
+	if (fds->infile > -1 && fds->infile != STDIN_FILENO)
 	{
-		dup2(fds.infile, STDIN_FILENO);
+		dup2(fds->infile, STDIN_FILENO);
+		close(fds->infile);
 	}
-	if (fds.outfile > -1 && fds.outfile != STDOUT_FILENO)
+	if (fds->outfile > -1 && fds->outfile != STDOUT_FILENO)
 	{
-		dup2(fds.outfile, STDOUT_FILENO);
+		dup2(fds->outfile, STDOUT_FILENO);
+		close(fds->outfile);
 	}
-	if (fds.errfile > -1 && fds.errfile != STDERR_FILENO)
+	if (fds->errfile > -1 && fds->errfile != STDERR_FILENO)
 	{
-		dup2(fds.errfile, STDERR_FILENO);
+		dup2(fds->errfile, STDERR_FILENO);
+		close(fds->errfile);
 	}
 }


### PR DESCRIPTION
En estos commits tienes algunos ajustes de la redicción de salida.

Y el más importante es el último commit donde una línea estaba rompiendo todo el procesamiento de los jobs a partir del primero.

Buscando el error, he modificado un poco el tema de los file descriptors para gestionar las redirecciones y los pipes. He metido un atributo dentro de la estructura t_process para almacenar los fds (in, out, err y pipe). No se utilizan los in, out, err pero para no bloquear esto, no he hecho para atrás. Sólo se utiliza el pipe. Mantenemos el proceso actual y el anterior. Y así en cada proceso, si tenemos pipe, tendremos que en el 1 tenemos el in del siguiente proceso y en el 0 tenemos el 1 al proceso actual (si esto no esta claro, que lo estoy escribiendo al vuelo y con algo de prisa, lo hablamos)