### PR TITLE
Redirecciones y pipes en builtins y corrección de errores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ UTILS 				= utils/ft_putnbr.c utils/ft_putstr.c utils/ft_split.c \
 	utils/redirections.c utils/ft_array_slide_left.c \
 	utils/ft_set_default_signals.c utils/ft_isinteger.c utils/std_fds.c	\
 	utils/ft_extract_redirections_from_argv.c \
-	utils/ft_count_words_until_separator.c utils/ft_expand_process_cmd.c
+	utils/ft_count_words_until_separator.c utils/ft_expand_process_cmd.c \
+	utils/pipes.c
 
 
 SRCS_WITHOUT_MAIN	=  srcs/ft_exit_minishell.c srcs/clearScreen.c \

--- a/minishell.h
+++ b/minishell.h
@@ -125,7 +125,7 @@ int					set_redirections(abs_struct *base, t_process *p);
 int					ft_expand_process_cmd(abs_struct *base, t_process *p);
 
 void				ft_launch_job(abs_struct *base, t_job *j);
-void            	ft_launch_process(abs_struct *base, t_process *previous, t_process *current);
+void            	ft_launch_process(abs_struct *base, t_process *p);
 int         		ft_execute_builtin(abs_struct *base, t_process *p);
 
 void				ft_release_base(abs_struct *base);

--- a/minishell.h
+++ b/minishell.h
@@ -122,11 +122,14 @@ t_process			*ft_build_processes(char *expanded_cmd);
 t_process			*ft_build_ctrl_d_process(void);
 t_process			*ft_build_process(char *expanded_cmd);
 int					set_redirections(abs_struct *base, t_process *p);
+void	            ft_set_pipes(t_process *previous, t_process *current);
+void				ft_close_pipes(t_files_fd fd, t_process *previous, t_process *current);
+void				ft_configure_pipes(abs_struct *base, t_process *current);
 int					ft_expand_process_cmd(abs_struct *base, t_process *p);
 
 void				ft_launch_job(abs_struct *base, t_job *j);
 void            	ft_launch_process(abs_struct *base, t_process *p);
-int         		ft_execute_builtin(abs_struct *base, t_process *p);
+int         		ft_execute_builtin(abs_struct *base, t_process *previous, t_process *p);
 
 void				ft_release_base(abs_struct *base);
 void				ft_release_jobs(t_job *job);

--- a/to_do.txt
+++ b/to_do.txt
@@ -1,11 +1,5 @@
 6.Comprobar/introducir el correcto funcionamiento de las variables de entorno
-10. Empezar a solucionar leaks:  compilar con flag -fsanitize=address para anotar los leaks que puedan salir al desarrollar
 11. $? funciona pero...¿igual deberia ir diferente?
 15. ¿Textos en inglés?
 21. Tratar los caracteres de borrado. Si escribimos un comando, borramos para corregir y reescribimos, ..., nosotros lo que ejecutaremos no es el result.ado que ve el usuario por pantalla sino todo el comando entero escrito incluyendo los caracteres de borrado, ...
 25. Al lanzar el comando: cat author | more (si el archivo pagina), y pulsamos Ctrl + c, nos finaliza la ejecución de minishell
-27. Revisar porqué falla el comando:
-export A=xxx; echo "$A" >victor 
-(OJO QUE HAY UN ESPACIO AL FINAL DEL COMANDO Y NO HAY QUE QUITARLO)
-28. Revisar porqué falla el comando pipe en el siguiente comando:
-echo "asdfj asdfj añsfj aslkj fasfj a" | more

--- a/to_do.txt
+++ b/to_do.txt
@@ -1,17 +1,10 @@
 6.Comprobar/introducir el correcto funcionamiento de las variables de entorno
-9. Mejoras si es posible en la estructura basica del codigo en caso de que la lógica general fallara
 10. Empezar a solucionar leaks:  compilar con flag -fsanitize=address para anotar los leaks que puedan salir al desarrollar
 11. $? funciona pero...¿igual deberia ir diferente?
 15. ¿Textos en inglés?
-18. Expandir ~ en el export. Por ejemplo: export HOME=~/42 en mi caso el ~ se tiene que expandir al valor actual de HOME que inicialmente es /home/visv
-* Esta parte se debe quedar corregida en la función ft_expand_cmd
 21. Tratar los caracteres de borrado. Si escribimos un comando, borramos para corregir y reescribimos, ..., nosotros lo que ejecutaremos no es el result.ado que ve el usuario por pantalla sino todo el comando entero escrito incluyendo los caracteres de borrado, ...
-22. Tratar las comillas en los comandos.
-* En el punto 18 muestra dónde está el punto común donde se procesa
-* Como función útil para implementar esto, tenemos la función ft_split_shell_by. Igual que el split pero teniendo en cuenta las comillas
-    Por ejemplo: "hola>mundo">42
-    Partido por: >
-    Nos da 2 tokens:
-    * "hola>mundo"
-    * 42
 25. Al lanzar el comando: cat author | more (si el archivo pagina), y pulsamos Ctrl + c, nos finaliza la ejecución de minishell
+26. Reubicar procesamiento de pipes y redirecciones
+    Ahora mismo los builtins por ejemplo no están procesando las redirecciones ni los pipes.
+    No funcionaría el comando: 
+        echo "hola mundo" > hola_mundo; echo "hola mundo" | more

--- a/to_do.txt
+++ b/to_do.txt
@@ -4,7 +4,8 @@
 15. ¿Textos en inglés?
 21. Tratar los caracteres de borrado. Si escribimos un comando, borramos para corregir y reescribimos, ..., nosotros lo que ejecutaremos no es el result.ado que ve el usuario por pantalla sino todo el comando entero escrito incluyendo los caracteres de borrado, ...
 25. Al lanzar el comando: cat author | more (si el archivo pagina), y pulsamos Ctrl + c, nos finaliza la ejecución de minishell
-26. Reubicar procesamiento de pipes y redirecciones
-    Ahora mismo los builtins por ejemplo no están procesando las redirecciones ni los pipes.
-    No funcionaría el comando: 
-        echo "hola mundo" > hola_mundo; echo "hola mundo" | more
+27. Revisar porqué falla el comando:
+export A=xxx; echo "$A" >victor 
+(OJO QUE HAY UN ESPACIO AL FINAL DEL COMANDO Y NO HAY QUE QUITARLO)
+28. Revisar porqué falla el comando pipe en el siguiente comando:
+echo "asdfj asdfj añsfj aslkj fasfj a" | more

--- a/utils/ft_build_process.c
+++ b/utils/ft_build_process.c
@@ -16,9 +16,9 @@ static int			ft_extract_fields(char *cmd, char ***argv)
 			if (!tmp)
 				continue ;
 			field = tmp;
+			if (!ft_array_add(argv, &fields, field))
+				return (-1);
 		}
-		if (!ft_array_add(argv, &fields, field))
-			return (-1);
 	}
 	return (fields);
 }

--- a/utils/ft_execute_builtin.c
+++ b/utils/ft_execute_builtin.c
@@ -24,6 +24,8 @@ int         ft_execute_builtin(abs_struct *base, t_process *p)
 	ft_putstr("\e[0m");
 	if ((!p->argv || !*p->argv) && ft_execute_ctrl_d(base))
 		return (1);
+	if (set_redirections(base, p))
+		return (0);
 	// TODO: Utilizar la definición del proceso en lugar del parseString y actual_argument
 	base->parseString = p->argv;
 	base->actual_argument = 0;

--- a/utils/ft_execute_builtin.c
+++ b/utils/ft_execute_builtin.c
@@ -1,13 +1,16 @@
 #include "minishell.h"
 
-static int	execute_environment_builtins(abs_struct *base, t_process *p)
+static int	execute_environment_builtins(abs_struct *base, t_process *previous, t_process *p)
 {
 	int		executed;
 
 	executed = 1;
 	base->parseString = p->argv;
 	if (!ft_strcmp(p->argv[0], "env"))
+	{
+		ft_set_pipes(previous,  p);
 		ft_env(base);
+	}
 	else if (!ft_strcmp(p->argv[0], "setenv"))
 		ft_setenv(base, p);
 	else if (!ft_strcmp(p->argv[0], "unset"))
@@ -19,7 +22,7 @@ static int	execute_environment_builtins(abs_struct *base, t_process *p)
 	return (executed);	
 }
 
-int         ft_execute_builtin(abs_struct *base, t_process *p)
+int         ft_execute_builtin(abs_struct *base, t_process *previous, t_process *p)
 {
 	ft_putstr("\e[0m");
 	if ((!p->argv || !*p->argv) && ft_execute_ctrl_d(base))
@@ -29,20 +32,32 @@ int         ft_execute_builtin(abs_struct *base, t_process *p)
 	// TODO: Utilizar la definición del proceso en lugar del parseString y actual_argument
 	base->parseString = p->argv;
 	base->actual_argument = 0;
-	if (execute_environment_builtins(base, p))
+	if (execute_environment_builtins(base, previous, p))
 		return (1);
 	if (!ft_strcmp(p->argv[0], "exit"))
 		ft_exit_minishell(base, 0);
 	else if (!ft_strcmp(p->argv[0], "echo"))
+	{
+		ft_set_pipes(previous, p);
 		echo(base, p);
+	}
 	else if (!ft_strcmp(p->argv[0], "pwd"))
+	{
+		ft_set_pipes(previous, p);
 		ft_pwd();
+	}
 	else if (!ft_strcmp(p->argv[0], "cd"))
 		cd(base);
 	else if (!ft_strcmp(p->argv[0], "history"))
+	{
+		ft_set_pipes(previous, p);
 		ft_history();
+	}
 	else if (!ft_strcmp(p->argv[0], "help"))
+	{
+		ft_set_pipes(previous, p);
 		ft_help(base);
+	}
 	else if (!ft_strcmp(p->argv[0], "clear"))
 		clearScreen();
 	else

--- a/utils/ft_launch_process.c
+++ b/utils/ft_launch_process.c
@@ -58,27 +58,11 @@ static void		ft_execute_shell_command_using_path(abs_struct *base,
 	p->status = 1;
 }
 
-static int		ft_set_std_fds(abs_struct *base, t_process *previous,
-	t_process *current)
-{
-	int			ret;
-
-	// TODO: Tratar los errores de dup2
-	if ((ret = set_redirections(base, current)))
-		return (ret);
-	if (previous && previous->pipe[STDIN_FILENO] > -1)
-		dup2(previous->pipe[STDIN_FILENO], STDIN_FILENO);
-	if (current->pipe[STDOUT_FILENO] > -1)
-		dup2(current->pipe[STDOUT_FILENO], STDOUT_FILENO);
-	return (0);
-}
-
-void            ft_launch_process(abs_struct *base, t_process *previous,
-	t_process *current)
+void            ft_launch_process(abs_struct *base, t_process *current)
 {
 	if ((current->status = ft_set_default_signals()))
 		return ;
-	current->status = ft_set_std_fds(base, previous, current);
+	current->status = set_redirections(base, current);
 	if (current->status)
 		return ;
 	if (*current->argv[0] == '/')

--- a/utils/pipes.c
+++ b/utils/pipes.c
@@ -1,0 +1,41 @@
+#include "minishell.h"
+
+void		ft_configure_pipes(abs_struct *base, t_process *current)
+{
+	if (current->next)
+	{
+		if (pipe(current->pipe) < 0)
+			ft_exit_minishell(base, errno);
+	}
+	else
+	{
+		current->pipe[STDIN_FILENO] = -1;
+		current->pipe[STDOUT_FILENO] = -1;
+	}
+}
+
+void		ft_close_pipes(t_files_fd fds, t_process *previous, t_process *current)
+{
+	// TODO: tratar errores de dup2
+	if (previous)
+	{
+		if (previous->pipe[STDIN_FILENO] > -1)
+		{
+			close(previous->pipe[STDIN_FILENO]);
+			dup2(fds.infile, STDIN_FILENO);
+		}
+	}
+	if (current->pipe[STDOUT_FILENO] > -1)
+	{
+		close(current->pipe[STDOUT_FILENO]);
+		dup2(fds.outfile, STDOUT_FILENO);
+	}
+}
+
+void			ft_set_pipes(t_process *previous, t_process *current)
+{
+	if (previous && previous->pipe[STDIN_FILENO] > -1)
+		dup2(previous->pipe[STDIN_FILENO], STDIN_FILENO);
+	if (current->pipe[STDOUT_FILENO] > -1)
+		dup2(current->pipe[STDOUT_FILENO], STDOUT_FILENO);
+}

--- a/utils/redirections.c
+++ b/utils/redirections.c
@@ -104,14 +104,18 @@ static int	set_redirection(abs_struct *base, char *i)
 		redirected = apply_output_add_redirection(base, fd, redir);
 	if (fd)
 		free(fd);
+	if (*(redir - 1) == '>' && !redirected)
+		return (0);
 	fd = 0;
-	if (redirected && (redir = i) &&
+	if (!redirected && (redir = i) &&
 		(fd = ft_split_shell_by(&redir, ">")) && *(redir - 1) == '>')
 		redirected = apply_output_redirection(base, fd, redir);
 	if (fd)
 		free(fd);
+	if (*(redir - 1) == '>' && !redirected)
+		return (0);
 	fd = 0;
-	if (redirected && (redir = i) &&
+	if (!redirected && (redir = i) &&
 		(fd = ft_split_shell_by(&redir, "<")) && *(redir - 1) == '<')
 		redirected = apply_input_redirection(base, fd, redir);
 	if (fd)


### PR DESCRIPTION
Con estos commits soluciono el problema del tratamiento de las redirecciones y pipes en los comandos builtins.
También se corrige el error que había al ejecutar el siguiente comando (ojo que hay un espacio al final del comando):
echo "hola" 
