### PR TITLE
Corrección de errores

### DIFF
--- a/minishell.h
+++ b/minishell.h
@@ -53,6 +53,7 @@ typedef struct				s_process
 	pid_t					pid;
 	char					completed;
 	char					stopped;
+	int						ctrl_d;
 	int						status;
 	int						pipe[2];
 }							t_process;
@@ -140,6 +141,7 @@ void						ft_update_status(t_abs_struct *base);
 
 t_job						*ft_build_jobs(char *command);
 t_job						*ft_build_job(char *command);
+t_job						*ft_build_job_ctrl_d(char *command);
 t_process					*ft_build_processes(char *expanded_cmd);
 t_process					*ft_build_ctrl_d_process(void);
 t_process					*ft_build_process(char *expanded_cmd);

--- a/srcs/ft_execute_ctrl_d.c
+++ b/srcs/ft_execute_ctrl_d.c
@@ -51,7 +51,10 @@ int			ft_execute_ctrl_d(t_abs_struct *base)
 	base->ctrl_d_times++;
 	ctrl_d_times = determine_ctrl_d_times(base);
 	if (ctrl_d_times < base->ctrl_d_times)
+	{
+		ft_putstr("exit\n");
 		ft_exit_minishell(base, 0);
+	}
 	ft_putstr("\e[0mUse <<exit>> to close shell\n");
 	return (1);
 }

--- a/srcs/ft_export.c
+++ b/srcs/ft_export.c
@@ -12,7 +12,42 @@
 
 #include "minishell.h"
 
-int		ft_export(t_abs_struct *base, t_process *p)
+static int	ft_print_declare(char *env)
 {
-	return (ft_setenv(base, p));
+	int		space;
+	char	*value;
+
+	if (!(value = ft_strchr(env, '=')))
+		return (0);
+	space = ft_isspace(*(value + 1));
+	ft_putstr("declare -x ");
+	ft_putnstr(env, (value - env + 1));
+	if (space)
+		ft_putstr("\"");
+	ft_putstr((env + (value - env + 1)));
+	if (space)
+		ft_putstr("\"");
+	ft_putstr("\n");
+	return (1);
+}
+
+static int	ft_print_declares(t_abs_struct *base)
+{
+	char	**it;
+
+	it = base->env;
+	while (it && *it)
+	{
+		ft_print_declare(*it);
+		it++;
+	}
+	return (1);
+}
+
+int			ft_export(t_abs_struct *base, t_process *p)
+{
+	if (!p->argv[1])
+		return (ft_print_declares(base));
+	else
+		return (ft_setenv(base, p));
 }

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -38,11 +38,12 @@ static void			execute_command_read(t_abs_struct *base)
 	t_job			*job;
 
 	job = ft_build_jobs(base->string);
+	base->first_job = job;
 	while (job)
 	{
-		base->first_job = job;
 		ft_launch_job(base, job);
 		job = ft_release_job(job);
+		base->first_job = job;
 	}
 }
 

--- a/srcs/setenv.c
+++ b/srcs/setenv.c
@@ -127,7 +127,8 @@ int				ft_setenv(t_abs_struct *base, t_process *p)
 		if (ft_search_env(base->env, key_value[0]))
 			ft_unset(base, p);
 		trimmed = ft_prepare_export(key_value[0], key_value[1]);
-		if (!trimmed || !(ret = ft_add_line(&base->env, &base->lines_envp, trimmed)))
+		if (!trimmed || !(ret = ft_add_line(&base->env, &base->lines_envp,
+			trimmed)))
 			ft_putstr("\e[0mNo se añadió el argumento\n");
 		ft_array_release(key_value);
 		if (trimmed)

--- a/srcs/setenv.c
+++ b/srcs/setenv.c
@@ -88,19 +88,50 @@ static int		ft_search_env(char **env, char *key)
 	return (0);
 }
 
+static char		*ft_prepare_export(char *key, char *value)
+{
+	char		*adjusted;
+	char		*trimmed;
+
+	if (!key || !value)
+		return (0);
+	if (ft_isspace(*value))
+		trimmed = ft_strdup("");
+	else
+		trimmed = ft_strdup(value);
+	if (!trimmed)
+		return (0);
+	ft_remove_quotes(trimmed);
+	if (!(adjusted = ft_calloc(ft_strlen(key) + 1 + ft_strlen(trimmed) + 1,
+		sizeof(char))))
+	{
+		free(trimmed);
+		return (0);
+	}
+	ft_memcpy(adjusted, key, ft_strlen(key));
+	adjusted[ft_strlen(key)] = '=';
+	ft_memcpy(adjusted + ft_strlen(key) + 1, trimmed, ft_strlen(trimmed));
+	free(trimmed);
+	return (adjusted);
+}
+
 int				ft_setenv(t_abs_struct *base, t_process *p)
 {
 	int			ret;
 	char		**key_value;
+	char		*trimmed;
 
 	key_value = ft_split(p->argv[1], '=');
 	if (key_value)
 	{
 		if (ft_search_env(base->env, key_value[0]))
 			ft_unset(base, p);
-		if (!(ret = ft_add_line(&base->env, &base->lines_envp, p->argv[1])))
+		trimmed = ft_prepare_export(key_value[0], key_value[1]);
+		if (!trimmed || !(ret = ft_add_line(&base->env, &base->lines_envp, trimmed)))
 			ft_putstr("\e[0mNo se añadió el argumento\n");
 		ft_array_release(key_value);
+		if (trimmed)
+			free(trimmed);
 		return (ret);
 	}
 	ft_putstr("\e[0mError en los argumentos\n");

--- a/to_do.txt
+++ b/to_do.txt
@@ -10,11 +10,7 @@
 26. Jugar con el minishell y tratar de romperlo
 27. Revisar este comando porque explota y aunque le faltan unas comillas, no debe explotar nada:
  export A=hola; export B=" mundo"; echo "$A$B >victor; cat victor | more
-28. Eliminar comillas en el export (tratar de utilizar ft_remove_quotes):
-    export B=" mundo";
-    Al ejecutar env nos muestra:
-    B=" mundo"
-    
+29. Comprobar en mac si al ejecutar export sin nada, nos muestra: declare -x a=valor. Si no lo hace. Modificar ft_export.c para que no lo haga
 
 comentarios de setenv.c
 // TODO: modificar el nombre de fichero por ft_setenv.c

--- a/to_do.txt
+++ b/to_do.txt
@@ -8,8 +8,6 @@
     * <&fd- -> comprobar que el fd está abierto como entrada (sino error) (stat)
 25. Revisar el proceso de evaluación para ver si cumplimos con todo
 26. Jugar con el minishell y tratar de romperlo
-27. Revisar este comando porque explota y aunque le faltan unas comillas, no debe explotar nada:
- export A=hola; export B=" mundo"; echo "$A$B >victor; cat victor | more
 29. Comprobar en mac si al ejecutar export sin nada, nos muestra: declare -x a=valor. Si no lo hace. Modificar ft_export.c para que no lo haga
 
 comentarios de setenv.c

--- a/utils/ft_build_job.c
+++ b/utils/ft_build_job.c
@@ -12,6 +12,20 @@
 
 #include "minishell.h"
 
+t_job			*ft_build_job_ctrl_d(char *command)
+{
+	t_job		*j;
+
+	if (!(j = ft_calloc(1, sizeof(t_job))))
+		return (0);
+	j->command = ft_strdup(command);
+	j->std_fds.errfile = STDERR_FILENO;
+	j->std_fds.infile = STDIN_FILENO;
+	j->std_fds.outfile = STDOUT_FILENO;
+	j->first_process = ft_build_ctrl_d_process();
+	return (j);
+}
+
 t_job			*ft_build_job(char *command)
 {
 	t_job		*j;

--- a/utils/ft_build_jobs.c
+++ b/utils/ft_build_jobs.c
@@ -19,6 +19,8 @@ t_job			*ft_build_jobs(char *command)
 	t_job		*jobs;
 	t_job		*job;
 
+	if (command && !(*command))
+		return (ft_build_job_ctrl_d(command));
 	jobs = 0;
 	job = 0;
 	cmd_i = command;

--- a/utils/ft_build_process.c
+++ b/utils/ft_build_process.c
@@ -43,9 +43,8 @@ t_process			*ft_build_ctrl_d_process(void)
 
 	if (!(proc = ft_calloc(1, sizeof(t_process))))
 		return (0);
-	proc->ctrl_d=1;
+	proc->ctrl_d = 1;
 	return (proc);
-
 }
 
 t_process			*ft_build_process(char *cmd)

--- a/utils/ft_build_process.c
+++ b/utils/ft_build_process.c
@@ -37,6 +37,17 @@ static int			ft_extract_fields(char *cmd, char ***argv)
 	return (fields);
 }
 
+t_process			*ft_build_ctrl_d_process(void)
+{
+	t_process		*proc;
+
+	if (!(proc = ft_calloc(1, sizeof(t_process))))
+		return (0);
+	proc->ctrl_d=1;
+	return (proc);
+
+}
+
 t_process			*ft_build_process(char *cmd)
 {
 	t_process		*proc;

--- a/utils/ft_execute_builtin.c
+++ b/utils/ft_execute_builtin.c
@@ -87,8 +87,12 @@ int					ft_execute_builtin(t_abs_struct *base, t_process *previous,
 	t_process *p)
 {
 	ft_putstr("\e[0m");
-	if ((!p->argv || !*p->argv) && ft_execute_ctrl_d(base))
+	if (!p->argv || !*p->argv)
+	{
+		if (p->ctrl_d)
+			return (ft_execute_ctrl_d(base));
 		return (1);
+	}
 	if (set_redirections(base, p))
 		return (0);
 	base->parse_string = p->argv;

--- a/utils/ft_expand_process_cmd.c
+++ b/utils/ft_expand_process_cmd.c
@@ -63,7 +63,7 @@ int					ft_expand_process_cmd(t_abs_struct *base, t_process *p)
 	if (!p)
 		return (1);
 	to_expand = p->argv;
-	while (*to_expand)
+	while (to_expand && *to_expand)
 	{
 		if (!(expanded_slice = expand(base, *to_expand)))
 			return (0);

--- a/utils/ft_expand_process_cmd_utils.c
+++ b/utils/ft_expand_process_cmd_utils.c
@@ -59,30 +59,29 @@ static char						*ft_getenv_value(char **env, char *key,
 
 int								ft_expand_dollar(t_expand_dollar *d)
 {
-	t_expand_dollar_internal	internal;
+	t_expand_dollar_internal	i;
 
 	(d->cmd)++;
-	internal.key = ft_extract_variable_name(&d->cmd);
-	internal.key_len = ft_strlen(internal.key);
-	internal.variable = ft_getenv_value(d->base->env, internal.key,
-		&internal.key_len);
-	if (!internal.variable)
+	i.key = ft_extract_variable_name(&d->cmd);
+	i.key_len = ft_strlen(i.key);
+	i.variable = ft_getenv_value(d->base->env, i.key, &i.key_len);
+	if (!i.variable)
 		return (1);
-	internal.variable_len = ft_strlen(internal.variable);
-	if ((internal.variable_len + 1) > internal.key_len)
+	i.variable_len = ft_strlen(i.variable);
+	if ((i.variable_len + 1) > i.key_len)
 	{
-		d->expanded_len = d->expanded_len + internal.variable_len
-			- internal.key_len - 1 + 1;
-		if (!(internal.tmp = ft_calloc(d->expanded_len + 1, sizeof(char))))
+		d->expanded_len = d->expanded_len + i.variable_len
+			- i.key_len - 1 + 1;
+		if (!(i.tmp = ft_calloc(d->expanded_len + 1, sizeof(char))))
 			return (0);
 		if (d->expanded)
 		{
-			ft_strlcat(internal.tmp, d->expanded, d->pos + 1);
+			ft_strlcat(i.tmp, d->expanded, d->pos + 1);
 			free(d->expanded);
 		}
-		d->expanded = internal.tmp;
+		d->expanded = i.tmp;
 	}
-	ft_memcpy(d->expanded + d->pos, internal.variable, internal.variable_len);
-	d->pos += internal.variable_len;
+	ft_memcpy(d->expanded + d->pos, i.variable, i.variable_len);
+	d->pos += i.variable_len;
 	return (1);
 }

--- a/utils/ft_expand_process_cmd_utils.c
+++ b/utils/ft_expand_process_cmd_utils.c
@@ -65,10 +65,10 @@ int								ft_expand_dollar(t_expand_dollar *d)
 	i.key = ft_extract_variable_name(&d->cmd);
 	i.key_len = ft_strlen(i.key);
 	i.variable = ft_getenv_value(d->base->env, i.key, &i.key_len);
-	if (!i.variable)
-		return (1);
+	if (!i.variable && !i.key_len)
+		i.variable = "$";
 	i.variable_len = ft_strlen(i.variable);
-	if ((i.variable_len + 1) > i.key_len)
+	if (i.variable && *(i.variable) != '$' && (i.variable_len + 1) > i.key_len)
 	{
 		d->expanded_len = d->expanded_len + i.variable_len
 			- i.key_len - 1 + 1;

--- a/utils/ft_launch_job.c
+++ b/utils/ft_launch_job.c
@@ -40,7 +40,7 @@ void			ft_launch_job(t_abs_struct *base, t_job *j)
 {
 	t_process	*current;
 	t_process	*previous;
-
+	
 	dup_std_fds(&j->std_fds);
 	previous = 0;
 	current = j->first_process;

--- a/utils/ft_launch_job.c
+++ b/utils/ft_launch_job.c
@@ -40,7 +40,7 @@ void			ft_launch_job(t_abs_struct *base, t_job *j)
 {
 	t_process	*current;
 	t_process	*previous;
-	
+
 	dup_std_fds(&j->std_fds);
 	previous = 0;
 	current = j->first_process;

--- a/utils/ft_remove_quotes.c
+++ b/utils/ft_remove_quotes.c
@@ -12,11 +12,11 @@
 
 #include "minishell.h"
 
-void			ft_remove_quotes(char *field)
+void				ft_remove_quotes(char *field)
 {
 	size_t			len;
 	size_t			pos;
-	
+
 	len = ft_strlen(field);
 	if (!len)
 		return ;

--- a/utils/ft_remove_quotes.c
+++ b/utils/ft_remove_quotes.c
@@ -16,7 +16,7 @@ void			ft_remove_quotes(char *field)
 {
 	size_t			len;
 	size_t			pos;
-
+	
 	len = ft_strlen(field);
 	if (!len)
 		return ;

--- a/utils/ft_split_shell.c
+++ b/utils/ft_split_shell.c
@@ -61,7 +61,8 @@ char			*ft_split_shell_by(char **str, char *separator)
 			ptr = find_next_single_quote(ptr + 1);
 		if (*separator != '"' && *ptr == '"')
 			ptr = find_next_double_qoute(ptr + 1);
-		ptr++;
+		if (*ptr)
+			ptr++;
 	}
 	len = ptr - (*str) + 1;
 	if (!(splitted = ft_calloc(len, sizeof(char))))

--- a/utils/ft_trim.c
+++ b/utils/ft_trim.c
@@ -27,7 +27,7 @@ char			*ft_trim(char *str)
 	while (start < end && ft_isspace(*(str + end)))
 		end--;
 	if (start > end)
-		return (0);
+		start = end;
 	if (!(trimmed = ft_calloc(end - start + 2, sizeof(char))))
 		return (0);
 	ft_memcpy(trimmed, str + start, (end - start + 1));


### PR DESCRIPTION
Comillas en export. Se guardaban las comiilas del comando: export a=" x "
Añadida funcionalidad. Al ejecutar export sin nada, muestra:
   declare -x variable=valor