### PR TITLE
Utilizando get_next_line para no tener límite en la línea de entrada

### DIFF
--- a/minishell.h
+++ b/minishell.h
@@ -17,7 +17,6 @@
 # include <sys/types.h>
 # include <sys/stat.h>
 # include <stdio.h>
-# include <string.h>
 # include <fcntl.h>
 # include <stddef.h>
 # include <stdlib.h>
@@ -37,6 +36,10 @@
 # define ANSI_COLOR_MAGENTA "\x1b[35m"
 # define ANSI_COLOR_CYAN    "\x1b[36m"
 # define ANSI_COLOR_RESET   "\x1b[0m"
+
+# ifndef BUFFER_SIZE
+#  define BUFFER_SIZE 4096
+# endif
 
 typedef struct				s_files_fd
 {
@@ -73,7 +76,7 @@ typedef struct				s_abs_struct
 	char					**env;
 	int						num_args;
 	int						lines_envp;
-	char					string[1024];
+	char					*input;
 	char					**parse_string;
 	int						actual_argument;
 	int						error;
@@ -175,7 +178,6 @@ void						forked_process_signal_handler(int sig);
 void						dup_std_fds(t_files_fd *fds);
 void						restore_std_fds(t_files_fd *fds);
 int							ft_extract_redirections_from_argv(t_process *p);
-
 size_t						ft_strlcat(char *dst, const char *src, size_t size);
 char						*ft_strlcat_paths(char *prefix_path,
 	const char *relative_path);

--- a/srcs/history.c
+++ b/srcs/history.c
@@ -16,18 +16,28 @@ int			ft_history(void)
 {
 	int		fd;
 	int		num;
-	char	**line;
+	char	*line;
 
 	num = 1;
-	line = malloc(sizeof((char**)line) * 1);
+	line = 0;
 	fd = open("history.txt", O_RDWR);
-	while (get_next_line(fd, line) > 0)
+	while (get_next_line(fd, &line) > 0)
 	{
 		ft_putstr("\e[0m  ");
 		ft_putnbr(num++);
 		ft_putstr(" - ");
-		ft_putstr(*line);
+		ft_putstr(line);
 		ft_putstr("\n");
+		if (line)
+		{
+			free(line);
+			line = 0;
+		}
+	}
+	if (line)
+	{
+		free(line);
+		line = 0;
 	}
 	close(fd);
 	return (1);

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -14,21 +14,26 @@
 
 int					obtain_full_line(t_abs_struct *base)
 {
-	char			c;
 	int				fd;
-	int				i;
+	int				found_new_line;
+	char			*tmp;
 
 	fd = open("history.txt", O_RDWR | O_APPEND);
-	i = 0;
-	while (read(0, &c, sizeof(char)) > 0)
+	if (base->input)
+		free(base->input);
+	base->input = 0;
+	found_new_line = 0;
+	while (!found_new_line)
 	{
-		write(fd, &c, 1);
-		base->string[i] = c;
-		i++;
-		if (c == '\n')
-			break ;
+		found_new_line = get_next_line(STDIN_FILENO, &base->input);
+		if (found_new_line < 0)
+			ft_exit_minishell(base, 2);
 	}
-	base->string[i] = '\0';
+	if (!base->input || !(tmp = ft_strjoin(base->input, "\n")))
+		ft_exit_minishell(base, 1);
+	free(base->input);
+	base->input = tmp;
+	write(fd, base->input, ft_strlen(base->input));
 	close(fd);
 	return (0);
 }
@@ -37,7 +42,7 @@ static void			execute_command_read(t_abs_struct *base)
 {
 	t_job			*job;
 
-	job = ft_build_jobs(base->string);
+	job = ft_build_jobs(base->input);
 	base->first_job = job;
 	while (job)
 	{

--- a/tests/test_echo.c
+++ b/tests/test_echo.c
@@ -4,13 +4,16 @@ int				test_echo(void)
 {
 	int			res;
 	t_abs_struct	abs;
+	t_process	p;
 
 	printf("--- Test echo\n");
 	memset(&abs, 0, sizeof(t_abs_struct));
 	abs.parse_string = calloc(3, sizeof(char *));
 	abs.parse_string[0] = "echo";
 	abs.parse_string[1] = "hola";
-	res = echo(&abs);
+	ft_memset(&p, 0, sizeof(t_process));
+	p.argv = abs.parse_string;
+	res = echo(&abs, &p);
 	free(abs.parse_string);
 	printf("--- \n\n\n");
 	return (res ? 0 : 1);

--- a/to_do.txt
+++ b/to_do.txt
@@ -1,4 +1,3 @@
-11. $? funciona pero...¿igual deberia ir diferente?
 15. ¿Textos en inglés?
 21. Tratar los caracteres de borrado. Si escribimos un comando, borramos para corregir y reescribimos, ..., nosotros lo que ejecutaremos no es el result.ado que ve el usuario por pantalla sino todo el comando entero escrito incluyendo los caracteres de borrado, ...
 22. Revisar builtins para que ejecuten utilizando el t_process
@@ -9,6 +8,7 @@
 25. Revisar el proceso de evaluación para ver si cumplimos con todo
 26. Jugar con el minishell y tratar de romperlo
 29. Comprobar en mac si al ejecutar export sin nada, nos muestra: declare -x a=valor. Si no lo hace. Modificar ft_export.c para que no lo haga
+30. No funciona $?
 
 comentarios de setenv.c
 // TODO: modificar el nombre de fichero por ft_setenv.c

--- a/to_do.txt
+++ b/to_do.txt
@@ -8,7 +8,9 @@
 25. Revisar el proceso de evaluación para ver si cumplimos con todo
 26. Jugar con el minishell y tratar de romperlo
 29. Comprobar en mac si al ejecutar export sin nada, nos muestra: declare -x a=valor. Si no lo hace. Modificar ft_export.c para que no lo haga
-30. No funciona $?
+30. No funciona $? . Siempre nos muestra 0
+31. Tenemos que tratar el ctrl+z? Si hacemos un more minishell.h y pulsamos ctrl+z debería detener el proceso pero creo que no es necesario contemplar los procesos detenidos
+
 
 comentarios de setenv.c
 // TODO: modificar el nombre de fichero por ft_setenv.c

--- a/utils/ft_expand_process_cmd.c
+++ b/utils/ft_expand_process_cmd.c
@@ -12,6 +12,38 @@
 
 #include "minishell.h"
 
+static void			ft_print_last_process_status(t_expand_dollar *d)
+{
+	char			*expansion;
+	char			*status;
+	int				len;
+
+	status = ft_itoa(!d->base->last_executed_process ? 0 :
+		d->base->last_executed_process->status);
+	if (!status)
+		ft_exit_minishell(d->base, 1);
+	len = ft_strlen(status);
+	if (len > 2)
+	{
+		if (!(expansion = ft_calloc(d->expanded_len + (len - 2) + 1,
+			sizeof(char))))
+			ft_exit_minishell(d->base, 1);
+		ft_memcpy(expansion, d->expanded, d->pos);
+		ft_memcpy(expansion + d->pos, status, len);
+		d->pos += len;
+		free(d->expanded);
+		d->expanded = expansion;
+		d->expanded_len += (len - 2);
+	}
+	else
+	{
+		ft_memcpy(d->expanded + d->pos, status, len);
+		d->pos += len;
+	}
+	d->cmd += 2;
+	free(status);
+}
+
 static void			expand_char(t_expand_dollar *d)
 {
 	if (d->scape)
@@ -26,7 +58,10 @@ static void			expand_char(t_expand_dollar *d)
 		d->quote = (!d->quote ? '"' : d->quote);
 	else if (*d->cmd == '$' && (d->quote || !d->single_quote))
 	{
-		ft_expand_dollar(d);
+		if (*(d->cmd + 1) == '?')
+			ft_print_last_process_status(d);
+		else
+			ft_expand_dollar(d);
 		return ;
 	}
 	else if (*d->cmd == '\\')

--- a/utils/ft_release_base.c
+++ b/utils/ft_release_base.c
@@ -16,6 +16,8 @@ void		ft_release_base(t_abs_struct *base)
 {
 	if (!base)
 		return ;
+	if (base->input)
+		free(base->input);
 	ft_array_release(base->env);
 	base->parse_string = 0;
 	ft_release_jobs(base->first_job);


### PR DESCRIPTION
En esta pull request incluyo el cambio para utilizar el get_next_line en lugar de utilizar el array de chars estático.
He eliminado el atributo estático de la estructura t_abs_struct