### PR TITLE
Correcciones de errores

### DIFF
--- a/srcs/cd.c
+++ b/srcs/cd.c
@@ -48,8 +48,8 @@ int	cd(t_abs_struct *base)
 
 	base->num_args = ft_count_until_separator(base->parse_string, base->a);
 	aux_nb = value_to_aux(base->num_args);
-	base->error = aux_nb;
-	if (aux_nb == 0)
+	base->error = !aux_nb;
+	if (base->error)
 		ft_putstr("\e[0mcd: Too many arguments\n");
 	else if (base->num_args > 1 && !ft_isempty(base->parse_string[base->a + 1]))
 		home = ft_get_absolute_path(base, base->parse_string[base->a + 1]);

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -42,7 +42,7 @@ int	obtain_full_line(t_abs_struct *base)
 		if (found_new_line < 0)
 			ft_exit_minishell(base, 2);
 	}
-	if (base->input && *base->input && !append_new_line(&base->input))
+	if (base->input && found_new_line && !append_new_line(&base->input))
 		ft_exit_minishell(base, 1);
 	write(fd, base->input, ft_strlen(base->input));
 	close(fd);

--- a/utils/ft_itoa.c
+++ b/utils/ft_itoa.c
@@ -14,10 +14,10 @@
 
 long	value_of_r_pos(int sign, long n)
 {
-	if ('0' + (sign < 0))
-		return (-n % 10);
+	if (sign < 0)
+		return '0' + (-n % 10);
 	else
-		return (n % 10);
+		return '0' + (n % 10);
 }
 
 char	*ft_itoa(int n2)


### PR DESCRIPTION
Corregido bug al interpretar el salto de línea como un ctrl+d. Finalizaba minishell
Corregido error en cd: Evitaba que se ejecutara el cambio de directorio.
Corregido error en itoa: No se parseaba correctamente el entero.