### PR TITLE
Navegación historial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ UTILS 				= utils/ft_putnbr.c utils/ft_putstr.c utils/ft_strchr.c \
 	utils/pipes.c utils/ft_remove_quotes.c \
 	utils/ft_expand_process_cmd_utils.c \
 	utils/ft_execute_absolute_shell_command.c \
-	utils/ft_execute_relative_shell_command.c
+	utils/ft_execute_relative_shell_command.c utils/ft_setlflag.c
 
 SRCS_WITHOUT_MAIN	=  srcs/ft_exit_minishell.c srcs/clear_screen.c \
 	srcs/ft_execute_ctrl_d.c srcs/echo.c srcs/cd.c \

--- a/minishell.h
+++ b/minishell.h
@@ -20,6 +20,7 @@
 # include <fcntl.h>
 # include <stddef.h>
 # include <stdlib.h>
+# include <termios.h>
 # include <unistd.h>
 # include <string.h>
 # include <ctype.h>
@@ -28,7 +29,10 @@
 # include <signal.h>
 # include <limits.h>
 
-# define BUFFER_SIZE		1024
+# define ARROW_UP			"\033[A"
+# define ARROW_DOWN			"\033[B"
+
+# define BUFFER_SIZE		1000
 # define ANSI_COLOR_RED     "\x1b[31m"
 # define ANSI_COLOR_GREEN   "\x1b[32m"
 # define ANSI_COLOR_YELLOW  "\x1b[33m"
@@ -84,6 +88,7 @@ typedef struct s_abs_struct
 	int						ctrl_d_times;
 	int						last_executed_process_status;
 	t_job					*first_job;
+	unsigned int			c_lflag;
 }							t_abs_struct;
 
 typedef struct s_expand_dollar
@@ -216,5 +221,6 @@ void			ft_execute_absolute_shell_command(t_abs_struct *base,
 					char *cmd, t_process *p);
 void			ft_execute_relative_shell_command(t_abs_struct *base,
 					t_process *p);
+int				ft_setlflag(int fd, int set_flag, unsigned int value);
 
 #endif

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -85,7 +85,8 @@ int	main(int argc, char **argv, char **envp)
 	if (minishell_ready)
 		clear_screen();
 	base.c_lflag = ft_getlflag(STDIN_FILENO); // Keep c_lflag value before changing anything
-	ft_setlflag(STDIN_FILENO, 0, ICANON|ECHO); // Disable canonical input and echoing
+	if (!ft_setlflag(STDIN_FILENO, 0, ICANON|ECHO))
+		ft_exit_minishell(&base, 1); // Exit minishell: Not disabled canonical input and echoing
 	while (minishell_ready)
 	{
 		ft_show_prompt(&base);

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -59,6 +59,20 @@ static void	execute_command_read(t_abs_struct *base)
 	}
 }
 
+unsigned int	ft_getlflag(int fd)
+{
+	struct termios	settings;
+	unsigned int	result;
+
+	if (tcgetattr (fd, &settings) < 0)
+	{
+		perror ("error in tcgetattr");
+		return 0;
+	}
+	result = settings.c_lflag;
+	return (result);
+}
+
 int	main(int argc, char **argv, char **envp)
 {
 	int				minishell_ready;
@@ -70,6 +84,8 @@ int	main(int argc, char **argv, char **envp)
 	minishell_ready = ft_init_minishell(&base, envp);
 	if (minishell_ready)
 		clear_screen();
+	base.c_lflag = ft_getlflag(STDIN_FILENO); // Keep c_lflag value before changing anything
+	ft_setlflag(STDIN_FILENO, 0, ICANON|ECHO); // Disable canonical input and echoing
 	while (minishell_ready)
 	{
 		ft_show_prompt(&base);

--- a/utils/ft_release_base.c
+++ b/utils/ft_release_base.c
@@ -22,5 +22,6 @@ void	ft_release_base(t_abs_struct *base)
 	base->parse_string = 0;
 	ft_release_jobs(base->first_job);
 	base->first_job = 0;
+	ft_setlflag(STDIN_FILENO, 1, base->c_lflag); // Restore original c_lflag values
 	return ;
 }

--- a/utils/ft_setlflag.c
+++ b/utils/ft_setlflag.c
@@ -1,0 +1,37 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_tcsetattr.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: visv <marvin@42.fr>                        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/04/10 18:49:03 by visv              #+#    #+#             */
+/*   Updated: 2021/04/10 18:49:06 by visv             ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+int	ft_setlflag(int fd, int set_flag, unsigned int value)
+{
+	struct termios	settings;
+	int				result;
+
+	result = tcgetattr (fd, &settings);
+	if (result < 0)
+	{
+		perror ("error in tcgetattr");
+		return 0;
+	}
+	settings.c_lflag &= ~value;
+	if (set_flag)
+		settings.c_lflag |= value;
+
+	result = tcsetattr (fd, TCSANOW, &settings);
+	if (result < 0)
+	{
+		perror ("error in tcsetattr");
+		return (0);
+	}
+	return (1);
+}

--- a/utils/get_next_line_visv.c
+++ b/utils/get_next_line_visv.c
@@ -18,12 +18,35 @@ static int	ft_move_buffer_to_line(char *bf, char **line)
 	int				found_nl;
 
 	new_line = ft_concat(*line, bf, &found_nl);
-	free(*line);
+	if (*line)
+		free(*line);
 	if (!new_line)
 		return (-1);
 	*line = new_line;
 	ft_shift_left(bf);
 	return (found_nl);
+}
+
+
+void	ft_erase(char **line)
+{
+	struct termios	settings;
+	int				result;
+	size_t			len;
+
+	if (!line || !(*line))
+		return ;
+	result = tcgetattr (STDIN_FILENO, &settings);
+	if (result < 0)
+	{
+		perror ("error in tcgetattr");
+		return ;
+	}
+	len = ft_strlen(*line);
+	while (len)
+		ft_putstr((char *)(&settings.c_cc[VERASE]));
+	free(*line);
+	*line = 0;
 }
 
 int	get_next_line(int fd, char **line)
@@ -41,11 +64,27 @@ int	get_next_line(int fd, char **line)
 	{
 		if (proc == 1)
 			return (1);
-		proc = read(fd, bf, BUFFER_SIZE);
+		proc = read(fd, bf, 4);
 		if (proc < 0)
 			return (-1);
 		if (!proc)
 			return (0);
+		if (!ft_strcmp(ARROW_UP, bf))
+		{
+			ft_erase(line);
+			ft_memcpy(bf, "ls -la\0", 7);
+			proc = ft_move_buffer_to_line(bf, line);
+			ft_putstr(*line);
+		}
+		else if (!ft_strcmp(ARROW_DOWN, bf))
+		{
+			ft_erase(line);
+			ft_memcpy(bf, "ls -la\0", 7);
+			proc = ft_move_buffer_to_line(bf, line);
+			ft_putstr(*line);
+		}
+		else
+			ft_putstr(bf);
 		if (proc < BUFFER_SIZE)
 			bf[proc] = 0;
 		proc = ft_move_buffer_to_line(bf, line);

--- a/utils/get_next_line_visv.c
+++ b/utils/get_next_line_visv.c
@@ -18,10 +18,10 @@ static int	ft_move_buffer_to_line(char *bf, char **line)
 	int				found_nl;
 
 	new_line = ft_concat(*line, bf, &found_nl);
-	if (*line)
-		free(*line);
 	if (!new_line)
 		return (-1);
+	if (*line)
+		free(*line);
 	*line = new_line;
 	ft_shift_left(bf);
 	return (found_nl);
@@ -33,6 +33,7 @@ void	ft_erase(char **line)
 	struct termios	settings;
 	int				result;
 	size_t			len;
+	size_t			erased;
 
 	if (!line || !(*line))
 		return ;
@@ -43,8 +44,12 @@ void	ft_erase(char **line)
 		return ;
 	}
 	len = ft_strlen(*line);
-	while (len)
+	erased = 0;
+	while (erased < len)
+	{
 		ft_putstr((char *)(&settings.c_cc[VERASE]));
+		erased++;
+	}
 	free(*line);
 	*line = 0;
 }
@@ -55,9 +60,6 @@ int	get_next_line(int fd, char **line)
 	int				proc;
 
 	if (fd < 0 || BUFFER_SIZE <= 0 || !line)
-		return (-1);
-	*line = ft_calloc(1, sizeof(char));
-	if (!(*line))
 		return (-1);
 	proc = ft_move_buffer_to_line(bf, line);
 	while (proc >= 0)
@@ -72,15 +74,17 @@ int	get_next_line(int fd, char **line)
 		if (!ft_strcmp(ARROW_UP, bf))
 		{
 			ft_erase(line);
-			ft_memcpy(bf, "ls -la\0", 7);
-			proc = ft_move_buffer_to_line(bf, line);
+			ft_memset(bf, 0, BUFFER_SIZE);
+			proc = 0;
+			*line = ft_strdup("ls -la");
 			ft_putstr(*line);
 		}
 		else if (!ft_strcmp(ARROW_DOWN, bf))
 		{
 			ft_erase(line);
-			ft_memcpy(bf, "ls -la\0", 7);
-			proc = ft_move_buffer_to_line(bf, line);
+			ft_memset(bf, 0, BUFFER_SIZE);
+			proc = 0;
+			*line = ft_strdup("ls -d");
 			ft_putstr(*line);
 		}
 		else


### PR DESCRIPTION
Planteamiento de implementación. No funciona
Funciona la captura del ARROW UP y DOWN una única vez.
Imprime una cadena fija en función de la tecla.
Queda pendiente:
* Resolver el problema que hace que solo se pueda pulsar 1 vez cada tecla.
* Utilizar el historial en lugar de las cadenas fijas.