### PR TITLE
Procesamiento de teclado y bugs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,10 +24,10 @@
             ]
         },
         {
-            "name": "(gdb) Debug pipes",
+            "name": "Debug minishell",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/pipes",
+            "program": "${workspaceFolder}/minishell",
             "args": [],
             "stopAtEntry": true,
             "cwd": "${workspaceFolder}",
@@ -37,12 +37,15 @@
             "setupCommands": [
                 {
                     "description": "Habilitar la impresión con sangría para gdb",
-                    "text": "-enable-pretty-printing",
+                    "text": "-enable-pretty-printing -gdb-set follow-fork-mode child",
                     "ignoreFailures": true
                 }
-            ]
+            ],
+            "envFile": "${workspaceFolder}/.env",
+            "preLaunchTask": "minishellBuildToDebug",
+            "miDebuggerPath": "/usr/bin/gdb"
         },
-                {
+        {
             "name": "Debug keyboard",
             "type": "cppdbg",
             "request": "launch",

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ UTILS 				= utils/ft_putnbr.c utils/ft_putstr.c utils/ft_strchr.c \
 	utils/ft_get_correct_line.c utils/ft_file_lines.c \
 	utils/ft_get_file_line.c utils/ft_open_history.c \
 	utils/ft_clear_input.c utils/ft_write_history_line.c \
-	utils/get_next_line_utils.c
+	utils/get_next_line_utils.c utils/load_history_commands.c \
+	utils/process_escape_sequences.c utils/process_csi_sequences.c
 
 SRCS_WITHOUT_MAIN	=  srcs/ft_exit_minishell.c srcs/clear_screen.c \
 	srcs/ft_execute_ctrl_d.c srcs/echo.c srcs/cd.c \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ UTILS 				= utils/ft_putnbr.c utils/ft_putstr.c utils/ft_strchr.c \
 	utils/ft_extract_redirections_from_argv.c \
 	utils/ft_count_words_until_separator.c utils/ft_expand_process_cmd.c \
 	utils/pipes.c utils/ft_remove_quotes.c \
-	utils/ft_expand_process_cmd_utils.c \
+	utils/ft_expand_process_cmd_utils.c utils/ft_expand_process_cmd_utils_2.c \
 	utils/ft_execute_absolute_shell_command.c \
 	utils/ft_execute_relative_shell_command.c utils/ft_setlflag.c \
 	utils/ft_classic_get_next.c utils/ft_get_count_line.c \
@@ -27,7 +27,8 @@ UTILS 				= utils/ft_putnbr.c utils/ft_putstr.c utils/ft_strchr.c \
 	utils/ft_get_file_line.c utils/ft_open_history.c \
 	utils/ft_clear_input.c utils/ft_write_history_line.c \
 	utils/get_next_line_utils.c utils/load_history_commands.c \
-	utils/process_escape_sequences.c utils/process_csi_sequences.c
+	utils/process_escape_sequences.c utils/process_csi_sequences.c \
+	utils/ft_print_last_process_status.c
 
 SRCS_WITHOUT_MAIN	=  srcs/ft_exit_minishell.c srcs/clear_screen.c \
 	srcs/ft_execute_ctrl_d.c srcs/echo.c srcs/cd.c \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.htm
 #### Keyboard processing
 ##### ANSI escape codes
 https://en.m.wikipedia.org/wiki/ANSI_escape_code
+##### ISO/IEC 2022
+https://en.m.wikipedia.org/wiki/ISO/IEC_2022
+##### C0 and C1 control codes
+https://en.m.wikipedia.org/wiki/C0_and_C1_control_codes
 
 #### Exit builtin
 https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html#Exit-Status -> interesting exit codes to check

--- a/minishell.h
+++ b/minishell.h
@@ -29,9 +29,15 @@
 # include <signal.h>
 # include <limits.h>
 
+# define CTRL_C				'\x3'
+# define DEL				'\x7F'
 # define ESCAPE				'\033'
+# define FE_ESCAPE_START	'\x40'
+# define FE_ESCAPE_END		'\x5F'
+# define CSI_ESCAPE			"\033["
 # define ARROW_UP			"\033[A"
 # define ARROW_DOWN			"\033[B"
+# define CLEAR_LINE			"\033[2K"
 
 # define ANSI_COLOR_RED     "\x1b[31m"
 # define ANSI_COLOR_GREEN   "\x1b[32m"
@@ -128,6 +134,7 @@ int				get_next_line(int fd, char **line, t_abs_struct *base);
 char			*ft_get_correct_line(int fd, char **line, int ret);
 char			*ft_concat(char *line, char *bf, int *found_nl);
 void			ft_shift_left(char *bf);
+void			ft_shift_left_bytes(char *bf, int bytes);
 char			*ft_strjoin(char const *s1, char const *s2);
 char			**ft_split(char const *s, char c);
 void			ft_putstr(char *s);
@@ -140,6 +147,10 @@ int				echo(t_abs_struct *base, t_process *p);
 int				ft_history(t_abs_struct *base);
 int				ft_open_history(t_abs_struct *base, int mode);
 void			ft_write_history_line(t_abs_struct *base);
+void			load_previous_history_command(t_abs_struct *base, char **line,
+	char *bf);
+void			load_next_history_command(t_abs_struct *base, char **line,
+	char *bf);
 int				ft_pwd(void);
 int				ft_export(t_abs_struct *base, t_process *p);
 int				ft_copy_env(t_abs_struct *base, char **envp);
@@ -240,6 +251,8 @@ char			*ft_get_file_line(char *file, int line);
 char			*ft_get_file_line_by_fd(int fd, int line);
 void			ft_clear_input(char **line);
 void			ft_delete_chars(int len);
-void			process_escape_sequences(char *bf, char **line, t_abs_struct *base);
-
+int				process_escape_sequences(char *bf, char **line,
+	t_abs_struct *base);
+int				process_csi_escape_sequence(char *bf, char **line,
+	t_abs_struct *base);
 #endif

--- a/minishell.h
+++ b/minishell.h
@@ -33,7 +33,6 @@
 # define ARROW_UP			"\033[A"
 # define ARROW_DOWN			"\033[B"
 
-# define BUFFER_SIZE		1000
 # define ANSI_COLOR_RED     "\x1b[31m"
 # define ANSI_COLOR_GREEN   "\x1b[32m"
 # define ANSI_COLOR_YELLOW  "\x1b[33m"
@@ -241,5 +240,6 @@ char			*ft_get_file_line(char *file, int line);
 char			*ft_get_file_line_by_fd(int fd, int line);
 void			ft_clear_input(char **line);
 void			ft_delete_chars(int len);
+void			process_escape_sequences(char *bf, char **line, t_abs_struct *base);
 
 #endif

--- a/minishell.h
+++ b/minishell.h
@@ -30,6 +30,7 @@
 # include <limits.h>
 
 # define CTRL_C				'\x3'
+# define CTRL_D				'\x4'
 # define DEL				'\x7F'
 # define ESCAPE				'\033'
 # define FE_ESCAPE_START	'\x40'
@@ -173,7 +174,7 @@ void			ft_update_status(t_abs_struct *base);
 
 t_job			*ft_build_jobs(char *command);
 t_job			*ft_build_job(char *command);
-t_job			*ft_build_job_ctrl_d(char *command);
+t_job			*ft_build_job_ctrl_d(void);
 t_process		*ft_build_processes(char *expanded_cmd);
 t_process		*ft_build_ctrl_d_process(void);
 t_process		*ft_build_process(char *expanded_cmd);

--- a/minishell.h
+++ b/minishell.h
@@ -190,6 +190,7 @@ void			ft_close_pipes(t_files_fd fd, t_process *previous, \
 				t_process *current);
 void			ft_configure_pipes(t_abs_struct *base, t_process *current);
 int				ft_expand_process_cmd(t_abs_struct *base, t_process *p);
+void			ft_expand_tilde(t_expand_dollar *d);
 
 void			ft_launch_job(t_abs_struct *base, t_job *j);
 void			ft_launch_process(t_abs_struct *base, t_process *p);
@@ -234,9 +235,11 @@ int				ft_isinteger(char *str);
 int				ft_count_until_separator(char **str, int actual_arg);
 int				ft_obtain_last(int fd, char **line);
 void			ft_remove_quotes(char *field);
-int				ft_expand_scape(char **res, char **cmd, size_t *pos);
 char			*ft_extract_variable_name(char **cmd);
+int				ft_expand_scape(t_expand_dollar *d);
 int				ft_expand_dollar(t_expand_dollar *d);
+void			ft_expand_quote(t_expand_dollar *d);
+void			ft_print_last_process_status(t_expand_dollar *d);
 void			ft_execute_absolute_shell_command(t_abs_struct *base,
 					char *cmd, t_process *p);
 void			ft_execute_relative_shell_command(t_abs_struct *base,

--- a/srcs/ft_exit_minishell.c
+++ b/srcs/ft_exit_minishell.c
@@ -14,7 +14,7 @@
 
 void	ft_exit_minishell(t_abs_struct *base, int exit_code)
 {
-	ft_setlflag(STDIN_FILENO, 1, ICANON | ECHO);
+	ft_setlflag(STDIN_FILENO, 1, base->c_lflag);
 	if (exit_code && errno != 0)
 	{
 		ft_putstr_fd(strerror(errno), STDERR_FILENO);

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -28,7 +28,8 @@ static int	append_new_line(char **str)
 
 int	obtain_full_line(t_abs_struct *base)
 {
-	int	found_new_line;
+	int		found_new_line;
+	char	*trimmed_input;
 
 	if (base->input)
 		free(base->input);
@@ -42,10 +43,12 @@ int	obtain_full_line(t_abs_struct *base)
 	}
 	if (base->input && found_new_line && !append_new_line(&base->input))
 		ft_exit_minishell(base, 1);
-	if (ft_strlen(base->input) >= 1 && ft_strcmp(ft_trim(base->input), "\n") \
+	trimmed_input = ft_trim(base->input);
+	if (ft_strlen(base->input) >= 1 && ft_strcmp(trimmed_input, "\n") \
 			&& ft_isascii(base->input[0]))
 		ft_write_history_line(base);
-	ft_setlflag(STDIN_FILENO, 1, base->c_lflag);
+	if (trimmed_input)
+		free(trimmed_input);
 	return (0);
 }
 
@@ -91,6 +94,8 @@ int	main(int argc, char **argv, char **envp)
 			ft_exit_minishell(&base, 1);
 		ft_show_prompt(&base);
 		obtain_full_line(&base);
+		if (!ft_setlflag(STDIN_FILENO, 1, base.c_lflag))
+			ft_exit_minishell(&base, 1);
 		execute_command_read(&base);
 		base.first_job = 0;
 		base.num_args = 0;

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -88,14 +88,12 @@ int	main(int argc, char **argv, char **envp)
 	if (minishell_ready)
 		clear_screen();
 	base.c_lflag = ft_getlflag(STDIN_FILENO);
+	if (!ft_setlflag(STDIN_FILENO, 0, ICANON | ECHO | IEXTEN | ISIG))
+		ft_exit_minishell(&base, 1);
 	while (minishell_ready)
 	{
-		if (!ft_setlflag(STDIN_FILENO, 0, ICANON | ECHO | IEXTEN | ISIG))
-			ft_exit_minishell(&base, 1);
 		ft_show_prompt(&base);
 		obtain_full_line(&base);
-		if (!ft_setlflag(STDIN_FILENO, 1, base.c_lflag))
-			ft_exit_minishell(&base, 1);
 		execute_command_read(&base);
 		base.first_job = 0;
 		base.num_args = 0;

--- a/to_do.txt
+++ b/to_do.txt
@@ -17,6 +17,9 @@ get_next_line_visv.c y get_next_line_utils_visv.c simplemente cambiando el makef
 comentarios de setenv.c
 38. Al borrar si no hay nada, escribe un espacio
 39. Si pulsamos la flecha a la izda, se va acumulando en el buffer y después nos permite borrar hasta que desaparecen todas las flechas y nos comemos todo
+40. Hacer un trim al comando a ejecutar, ahora mismo nos da error porque no conoce el comando al ejecutar:
+' exit'
+41. Después de ejecutar un comando, necesitamos 2 pulsaciones de arrow_up para que nos muestre el último elemento
 
 // TODO: modificar el nombre de fichero por ft_setenv.c
 // Problema al solo aceptar dos introducciones con setenv

--- a/to_do.txt
+++ b/to_do.txt
@@ -14,8 +14,10 @@ get_next_line_visv.c y get_next_line_utils_visv.c simplemente cambiando el makef
 36. Leak, ejecutando:
     export a=4243;echo $a$a$a$a$a
 37. Pendiente capturar señales para que al salir de minishell, se vuelva a activar ICANON Y ECHO, sino nos quedamos sin output
-
 comentarios de setenv.c
+38. Al borrar si no hay nada, escribe un espacio
+39. Si pulsamos la flecha a la izda, se va acumulando en el buffer y después nos permite borrar hasta que desaparecen todas las flechas y nos comemos todo
+
 // TODO: modificar el nombre de fichero por ft_setenv.c
 // Problema al solo aceptar dos introducciones con setenv
 

--- a/to_do.txt
+++ b/to_do.txt
@@ -20,10 +20,9 @@ comentarios de setenv.c
 40. Hacer un trim al comando a ejecutar, ahora mismo nos da error porque no conoce el comando al ejecutar:
 ' exit'
 41. Después de ejecutar un comando, necesitamos 2 pulsaciones de arrow_up para que nos muestre el último elemento
-42. Si pulsamos ESC, el siguiente caracter no se muestra en pantalla hasta que no escribimos un segundo
 43. El fichero de history no lo tratamos y si se mete cualquier cosa rara, va a hacer que el terminal haga cosas raras. Por ejemplo si se mete una secuencia de escape, se imprimirá directamente por pantalla y no quedará desactivada como cuando realizamos la entrada por teclado
-
-
+44. No se ejecuta el comando: more ~/history_visv.txt (problemas de path?)
+45. Al ejecutar un comando el historial no funciona si no hacemos dos pulsaciones hacia arriba
 // TODO: modificar el nombre de fichero por ft_setenv.c
 // Problema al solo aceptar dos introducciones con setenv
 

--- a/to_do.txt
+++ b/to_do.txt
@@ -21,6 +21,8 @@ comentarios de setenv.c
 ' exit'
 41. Después de ejecutar un comando, necesitamos 2 pulsaciones de arrow_up para que nos muestre el último elemento
 42. Si pulsamos ESC, el siguiente caracter no se muestra en pantalla hasta que no escribimos un segundo
+43. El fichero de history no lo tratamos y si se mete cualquier cosa rara, va a hacer que el terminal haga cosas raras. Por ejemplo si se mete una secuencia de escape, se imprimirá directamente por pantalla y no quedará desactivada como cuando realizamos la entrada por teclado
+
 
 // TODO: modificar el nombre de fichero por ft_setenv.c
 // Problema al solo aceptar dos introducciones con setenv

--- a/to_do.txt
+++ b/to_do.txt
@@ -11,18 +11,9 @@
 31. Tenemos que tratar el ctrl+z? Si hacemos un more minishell.h y pulsamos ctrl+z debería detener el proceso pero creo que no es necesario contemplar los procesos detenidos
 35. He visto que hay algo que puede fallar en la lectura del gnl para el history, si falla, he ajustado para utilizar:
 get_next_line_visv.c y get_next_line_utils_visv.c simplemente cambiando el makefile
-36. Leak, ejecutando:
-    export a=4243;echo $a$a$a$a$a
 37. Pendiente capturar señales para que al salir de minishell, se vuelva a activar ICANON Y ECHO, sino nos quedamos sin output
 comentarios de setenv.c
-38. Al borrar si no hay nada, escribe un espacio
-39. Si pulsamos la flecha a la izda, se va acumulando en el buffer y después nos permite borrar hasta que desaparecen todas las flechas y nos comemos todo
-40. Hacer un trim al comando a ejecutar, ahora mismo nos da error porque no conoce el comando al ejecutar:
-' exit'
-41. Después de ejecutar un comando, necesitamos 2 pulsaciones de arrow_up para que nos muestre el último elemento
 43. El fichero de history no lo tratamos y si se mete cualquier cosa rara, va a hacer que el terminal haga cosas raras. Por ejemplo si se mete una secuencia de escape, se imprimirá directamente por pantalla y no quedará desactivada como cuando realizamos la entrada por teclado
-44. No se ejecuta el comando: more ~/history_visv.txt (problemas de path?)
-45. Al ejecutar un comando el historial no funciona si no hacemos dos pulsaciones hacia arriba
 // TODO: modificar el nombre de fichero por ft_setenv.c
 // Problema al solo aceptar dos introducciones con setenv
 

--- a/to_do.txt
+++ b/to_do.txt
@@ -20,6 +20,7 @@ comentarios de setenv.c
 40. Hacer un trim al comando a ejecutar, ahora mismo nos da error porque no conoce el comando al ejecutar:
 ' exit'
 41. Después de ejecutar un comando, necesitamos 2 pulsaciones de arrow_up para que nos muestre el último elemento
+42. Si pulsamos ESC, el siguiente caracter no se muestra en pantalla hasta que no escribimos un segundo
 
 // TODO: modificar el nombre de fichero por ft_setenv.c
 // Problema al solo aceptar dos introducciones con setenv

--- a/utils/ft_build_job.c
+++ b/utils/ft_build_job.c
@@ -12,14 +12,14 @@
 
 #include "minishell.h"
 
-t_job	*ft_build_job_ctrl_d(char *command)
+t_job	*ft_build_job_ctrl_d(void)
 {
 	t_job		*j;
 
 	j = ft_calloc(1, sizeof(t_job));
 	if (!j)
 		return (0);
-	j->command = ft_strdup(command);
+	j->command = ft_strdup("");
 	j->std_fds.errfile = STDERR_FILENO;
 	j->std_fds.infile = STDIN_FILENO;
 	j->std_fds.outfile = STDOUT_FILENO;

--- a/utils/ft_build_jobs.c
+++ b/utils/ft_build_jobs.c
@@ -37,8 +37,8 @@ t_job	*ft_build_jobs(char *command)
 	t_job		*jobs;
 	t_job		*job;
 
-	if (command && !(*command))
-		return (ft_build_job_ctrl_d(command));
+	if (!command)
+		return (ft_build_job_ctrl_d());
 	jobs = 0;
 	job = 0;
 	cmd_i = command;

--- a/utils/ft_build_process.c
+++ b/utils/ft_build_process.c
@@ -28,7 +28,10 @@ static int	ft_extract_fields(char *cmd, char ***argv)
 			if (tmp)
 			{
 				if (!ft_array_add(argv, &fields, tmp))
+				{
+					free(field);
 					return (-1);
+				}
 			}
 		}
 		free(field);

--- a/utils/ft_classic_get_next.c
+++ b/utils/ft_classic_get_next.c
@@ -17,14 +17,11 @@ char	*ft_strsub(char const *s, unsigned int start, size_t len)
 	unsigned long int	o;
 	char				*c;
 
-	o = 0;
-	c = malloc(len + 1);
 	if (!s)
-	{
-		// TODO: fuga de memoria. Tenemos c con malloc pero sin liberar
 		return (0);
-	}
-	if (c == 0)
+	o = 0;
+	c = malloc(sizeof(char) * (len + 1));
+	if (!c)
 		return (0);
 	if (start < ft_strlen(s))
 	{
@@ -45,6 +42,8 @@ static	int	finalline(char **stat, char **line)
 	char			*c;
 
 	l = 0;
+	if (*line)
+		free(*line);
 	while ((*stat)[l] != '\n' && (*stat)[l] != '\0')
 		l++;
 	if ((*stat)[l] == '\n')

--- a/utils/ft_expand_process_cmd_utils.c
+++ b/utils/ft_expand_process_cmd_utils.c
@@ -19,11 +19,12 @@ int	give_int(int d)
 	return (1);
 }
 
-int	ft_expand_scape(char **res, char **cmd, size_t *pos)
+int	ft_expand_scape(t_expand_dollar *data)
 {
-	*((*res) + *pos) = **cmd;
-	(*cmd)++;
-	(*pos)++;
+	*(data->expanded + data->pos) = *data->cmd;
+	data->cmd++;
+	data->pos++;
+	data->scape = 0;
 	return (1);
 }
 

--- a/utils/ft_expand_process_cmd_utils_2.c
+++ b/utils/ft_expand_process_cmd_utils_2.c
@@ -1,0 +1,33 @@
+#include "minishell.h"
+
+void	ft_expand_quote(t_expand_dollar *d)
+{
+	if (!d->quote)
+		d->quote = '"';
+	d->cmd++;
+}
+
+void	ft_expand_tilde(t_expand_dollar *d)
+{
+	char	*tilde_path;
+	char	*tmp;
+
+	tilde_path = ft_get_absolute_path(d->base, "~");
+	if (!tilde_path)
+		return ;
+	tmp = ft_calloc(d->expanded_len + ft_strlen(tilde_path) + 2, sizeof(char));
+	if (!tmp)
+	{
+		free(tilde_path);
+		return ;
+	}
+	ft_memcpy(tmp, d->expanded, d->pos);
+	ft_memcpy(tmp + d->pos, tilde_path, ft_strlen(tilde_path));
+	if (d->expanded)
+		free(d->expanded);
+	d->expanded = tmp;
+	d->pos += ft_strlen(d->expanded);
+	d->expanded_len += ft_strlen(tilde_path) - 1;
+	free(tilde_path);
+	d->cmd += 2;
+}

--- a/utils/ft_get_absolute_path.c
+++ b/utils/ft_get_absolute_path.c
@@ -47,12 +47,18 @@ static char	*prepend_home_to_path(t_abs_struct *base, char *path)
 
 static char	*prepend_pwd_to_path(char *path)
 {
-	char		cwd[PATH_MAX];
+	char		*cwd;
+	char		*adjusted_path;
 
-	if (!getcwd(cwd, sizeof(cwd)))
+	cwd = getcwd(0, 0);
+	if (!cwd)
 		return (ft_strdup(path));
 	else
-		return (prepend_to_path(cwd, path));
+	{
+		adjusted_path = prepend_to_path(cwd, path);
+		free(cwd);
+		return (adjusted_path);
+	}
 }
 
 char	*ft_get_absolute_path(t_abs_struct *base, char *path)
@@ -67,7 +73,7 @@ char	*ft_get_absolute_path(t_abs_struct *base, char *path)
 	else if (*path == '/')
 		return (ft_strdup(path));
 	else
-	{	
+	{
 		if (!ft_memcmp(path, "./", 2))
 			aux = 2;
 		return (prepend_pwd_to_path(path + aux));

--- a/utils/ft_isinteger.c
+++ b/utils/ft_isinteger.c
@@ -20,7 +20,11 @@ int	ft_isinteger(char *str)
 
 	trimmed = ft_trim(str);
 	if (!str || *str == '\0' || !(trimmed))
+	{
+		if (trimmed)
+			free(trimmed);
 		return (0);
+	}
 	i = trimmed;
 	while (ft_isdigit(*i))
 		i++;

--- a/utils/ft_open_history.c
+++ b/utils/ft_open_history.c
@@ -20,8 +20,8 @@ int	ft_open_history(t_abs_struct *base, int mode)
 
 	if (!base)
 		return (-1);
-	home = ft_getenv(base->env, "PWD") + 4;
-	if (ft_strlen(home) == 4)
+	home = ft_getenv(base->env, "HOME") + 5;
+	if (ft_strlen(home) == 5)
 		return (-1);
 	history_path = ft_strjoin(home, "/history_visv.txt");
 	if (!history_path)

--- a/utils/ft_open_history.c
+++ b/utils/ft_open_history.c
@@ -21,7 +21,7 @@ int	ft_open_history(t_abs_struct *base, int mode)
 	if (!base)
 		return (-1);
 	home = ft_getenv(base->env, "PWD") + 4;
-	if (ft_strlen(home) == 5)
+	if (ft_strlen(home) == 4)
 		return (-1);
 	history_path = ft_strjoin(home, "/history_visv.txt");
 	if (!history_path)

--- a/utils/ft_print_last_process_status.c
+++ b/utils/ft_print_last_process_status.c
@@ -1,0 +1,29 @@
+#include "minishell.h"
+
+void	ft_print_last_process_status(t_expand_dollar *d)
+{
+	char			*expansion;
+	char			*status;
+	int				len;
+
+	status = ft_itoa(d->base->last_executed_process_status);
+	if (!(status))
+		ft_exit_minishell(d->base, 1);
+	len = ft_strlen(status);
+	if (len > 2)
+	{
+		expansion = ft_calloc(d->expanded_len + (len - 2) + 1, sizeof(char));
+		if (!(expansion))
+			ft_exit_minishell(d->base, 1);
+		ft_memcpy(expansion, d->expanded, d->pos);
+		ft_memcpy(expansion + d->pos, status, len);
+		free(d->expanded);
+		d->expanded = expansion;
+		d->expanded_len += (len - 2);
+	}
+	else
+		ft_memcpy(d->expanded + d->pos, status, len);
+	d->pos += len;
+	d->cmd += 2;
+	free(status);
+}

--- a/utils/ft_release_base.c
+++ b/utils/ft_release_base.c
@@ -22,6 +22,5 @@ void	ft_release_base(t_abs_struct *base)
 	base->parse_string = 0;
 	ft_release_jobs(base->first_job);
 	base->first_job = 0;
-	ft_setlflag(STDIN_FILENO, 1, base->c_lflag);
 	return ;
 }

--- a/utils/ft_write_history_line.c
+++ b/utils/ft_write_history_line.c
@@ -22,5 +22,5 @@ void	ft_write_history_line(t_abs_struct *base)
 	write(fd, base->input, ft_strlen(base->input));
 	close(fd);
 	base->history_lines++;
-	base->current_history_line = base->history_lines + 1;
+	base->current_history_line = base->history_lines;
 }

--- a/utils/get_next_line_utils.c
+++ b/utils/get_next_line_utils.c
@@ -21,9 +21,9 @@ char	*ft_strcdup(const char *s1, int c)
 	while (s1[i] != c && s1[i] != '\0')
 		i++;
 	str = malloc(sizeof(char) * (i + 1));
-	str[i] = '\0';
 	if (str == NULL)
 		return (NULL);
+	str[i] = '\0';
 	while (i-- > 0)
 		str[i] = s1[i];
 	return (str);

--- a/utils/get_next_line_utils_visv.c
+++ b/utils/get_next_line_utils_visv.c
@@ -63,31 +63,18 @@ void	ft_shift_left(char *bf)
 	*(bf + i) = 0;
 }
 
-static void	delete_char(char *bf)
-{
-	ft_delete_chars(1);
-	ft_memset(bf, 0, BUFFER_SIZE);
-}
-
 void	ft_borrow_char(int x, char **line, char *bf)
 {
 	char	*aux;
 
+	ft_memset(bf, 0, BUFFER_SIZE);
 	if (x > 0)
 	{
+		ft_delete_chars(1);
 		aux = malloc(sizeof(char) * x);
 		ft_strlcpy(aux, *line, ft_strlen(*line));
-		delete_char(bf);
 		if (*line)
 			free(*line);
-		*line = ft_strdup(aux);
-		free(aux);
-	}
-	else
-	{
-		ft_putstr(" ");
-		if (*line)
-			free(*line);
-		*line = ft_strdup("");
+		*line = aux;
 	}
 }

--- a/utils/get_next_line_utils_visv.c
+++ b/utils/get_next_line_utils_visv.c
@@ -39,9 +39,22 @@ char	*ft_concat(char *line, char *bf, int *found_nl)
 	return (nl);
 }
 
-void	ft_shift_left(char *bf)
+void	ft_shift_left_bytes(char *bf, int bytes)
 {
 	int				i;
+
+	i = 0;
+	while (bytes < BUFFER_SIZE)
+	{
+		*(bf + i) = *(bf + bytes);
+		i++;
+		bytes++;
+	}
+	*(bf + i) = 0;
+}
+
+void	ft_shift_left(char *bf)
+{
 	int				nl_pos;
 
 	nl_pos = 0;
@@ -52,15 +65,8 @@ void	ft_shift_left(char *bf)
 		*bf = 0;
 		return ;
 	}
-	i = 0;
 	nl_pos++;
-	while (nl_pos < BUFFER_SIZE)
-	{
-		*(bf + i) = *(bf + nl_pos);
-		i++;
-		nl_pos++;
-	}
-	*(bf + i) = 0;
+	ft_shift_left_bytes(bf, nl_pos);
 }
 
 void	ft_borrow_char(int x, char **line, char *bf)

--- a/utils/get_next_line_utils_visv.c
+++ b/utils/get_next_line_utils_visv.c
@@ -78,13 +78,16 @@ void	ft_borrow_char(int x, char **line, char *bf)
 		aux = malloc(sizeof(char) * x);
 		ft_strlcpy(aux, *line, ft_strlen(*line));
 		delete_char(bf);
-		ft_memset(bf, 0, BUFFER_SIZE);
+		if (*line)
+			free(*line);
 		*line = ft_strdup(aux);
 		free(aux);
 	}
 	else
 	{
 		ft_putstr(" ");
+		if (*line)
+			free(*line);
 		*line = ft_strdup("");
 	}
 }

--- a/utils/get_next_line_utils_visv.c
+++ b/utils/get_next_line_utils_visv.c
@@ -23,7 +23,7 @@ char	*ft_concat(char *line, char *bf, int *found_nl)
 	while (b2c < BUFFER_SIZE && *(bf + b2c) && *(bf + b2c) != '\n')
 		b2c++;
 	*found_nl = 0;
-	if (b2c < BUFFER_SIZE && *(bf + b2c) == '\n')
+	if (*(bf + b2c) == '\n')
 		*found_nl = 1;
 	line_len = ft_strlen(line);
 	nl = malloc(sizeof(char) * (line_len + b2c + 1));

--- a/utils/get_next_line_visv.c
+++ b/utils/get_next_line_visv.c
@@ -27,85 +27,11 @@ static int	ft_move_buffer_to_line(char *bf, char **line)
 	return (found_nl);
 }
 
-static void	load_previous_command(t_abs_struct *base, char **line, char *bf)
+static int	print_new_line(char *bf)
 {
-	int		fd;
-	char	*history_line;
-	char	*tmp;
-
-	if (base->current_history_line <= 0)
-		base->current_history_line = 0;
-	else
-		base->current_history_line--;
-	fd = ft_open_history(base, O_RDONLY);
-	if (fd < 0)
-		return ;
-	tmp = ft_get_file_line_by_fd(fd, base->current_history_line);
-	history_line = ft_trim(tmp);
-	if (tmp)
-		free(tmp);
-	if (fd)
-		close(fd);
-	if (!history_line)
-		return ;
-	ft_clear_input(line);
-	*line = history_line;
-	ft_memset(bf, 0, BUFFER_SIZE);
-	ft_putstr(*line);
-}
-
-static void	load_next_command(t_abs_struct *base, char **line, char *bf)
-{
-	int		fd;
-	char	*history_line;
-
-	if (base->current_history_line >= (base->history_lines - 1))
-	{
-		ft_clear_input(line);
-		ft_memset(bf, 0, BUFFER_SIZE);
-		base->current_history_line = base->history_lines;
-		return ;
-	}
-	fd = ft_open_history(base, O_RDONLY);
-	if (fd < 0)
-		return ;
-	base->current_history_line++;
-	history_line = ft_get_file_line_by_fd(fd, base->current_history_line);
-	close(fd);
-	if (!history_line)
-		return ;
-	ft_clear_input(line);
-	*line = history_line;
-	ft_memset(bf, 0, BUFFER_SIZE);
-	ft_putstr(*line);
-}
-
-int	ft_read_from_keyboard(char *bf, char **line, t_abs_struct *base, int fd)
-{
-	if (*bf == 127)
-		ft_borrow_char(ft_strlen(*line), line, bf);
-	else if (*bf == 27)
-	{
-		read(fd, bf, 1);
-		if (*bf == 91)
-		{
-			read(fd, bf, 1);
-			if (*bf == 65)
-				load_previous_command(base, line, bf);
-			else if (*bf == 66)
-				load_next_command(base, line, bf);
-		}
-	}
-	else if (*bf == 3)
-	{
-		ft_clear_input(line);
-		ft_putstr("\n");
-		ft_memset(bf, 0, BUFFER_SIZE);
-		return (1);
-	}
-	else
-		ft_putstr(bf);
-	return (0);
+	*bf = 0;
+	ft_putstr("\n");
+	return (1);
 }
 
 int	get_next_line(int fd, char **line, t_abs_struct *base)
@@ -113,21 +39,23 @@ int	get_next_line(int fd, char **line, t_abs_struct *base)
 	static char		bf[BUFFER_SIZE];
 	int				proc;
 
-	if (fd < 0 || BUFFER_SIZE <= 0 || !line)
-		return (-1);
 	proc = ft_move_buffer_to_line(bf, line);
-	while (proc >= 0)
+	while (fd >= 0 && BUFFER_SIZE >= 0 && proc >= 0)
 	{
 		if (proc == 1)
 			return (1);
-		proc = read(fd, bf, 1);
+		proc = read(fd, bf, 2);
 		if (proc < 0)
 			break ;
-		if (!proc)
-			return (0);
-		if (ft_read_from_keyboard(bf, line, base, fd) == 1)
-			return (1);
-		proc = ft_move_buffer_to_line(bf, line);
+		if (process_escape_sequences(bf, line, base))
+			proc = 0;
+		else if (*bf == '\n')
+			return (print_new_line(bf));
+		else
+		{
+			ft_putstr(bf);
+			proc = ft_move_buffer_to_line(bf, line);
+		}
 	}
 	if (*line)
 		free(*line);

--- a/utils/get_next_line_visv.c
+++ b/utils/get_next_line_visv.c
@@ -31,6 +31,7 @@ static void	load_previous_command(t_abs_struct *base, char **line, char *bf)
 {
 	int		fd;
 	char	*history_line;
+	char	*tmp;
 
 	if (base->current_history_line <= 0)
 		base->current_history_line = 0;
@@ -39,8 +40,10 @@ static void	load_previous_command(t_abs_struct *base, char **line, char *bf)
 	fd = ft_open_history(base, O_RDONLY);
 	if (fd < 0)
 		return ;
-	history_line = \
-		ft_trim(ft_get_file_line_by_fd(fd, base->current_history_line));
+	tmp = ft_get_file_line_by_fd(fd, base->current_history_line);
+	history_line = ft_trim(tmp);
+	if (tmp)
+		free(tmp);
 	if (fd)
 		close(fd);
 	if (!history_line)
@@ -121,7 +124,7 @@ int	get_next_line(int fd, char **line, t_abs_struct *base)
 			break ;
 		if (!proc)
 			return (0);
-		if (ft_read_from_keyboard(bf, &(*line), base, fd) == 1)
+		if (ft_read_from_keyboard(bf, line, base, fd) == 1)
 			return (1);
 		proc = ft_move_buffer_to_line(bf, line);
 	}

--- a/utils/get_next_line_visv.c
+++ b/utils/get_next_line_visv.c
@@ -100,6 +100,7 @@ int	ft_read_from_keyboard(char *bf, char **line, t_abs_struct *base, int fd)
 	{
 		ft_clear_input(line);
 		ft_putstr("\n");
+		ft_memset(bf, 0, BUFFER_SIZE);
 		return (1);
 	}
 	else

--- a/utils/load_history_commands.c
+++ b/utils/load_history_commands.c
@@ -1,0 +1,55 @@
+#include "minishell.h"
+
+void	load_previous_history_command(t_abs_struct *base, char **line,
+	char *bf)
+{
+	int		fd;
+	char	*history_line;
+	char	*tmp;
+
+	if (base->current_history_line <= 0)
+		base->current_history_line = 0;
+	else
+		base->current_history_line--;
+	fd = ft_open_history(base, O_RDONLY);
+	if (fd < 0)
+		return ;
+	tmp = ft_get_file_line_by_fd(fd, base->current_history_line);
+	history_line = ft_trim(tmp);
+	if (tmp)
+		free(tmp);
+	if (fd)
+		close(fd);
+	if (!history_line)
+		return ;
+	ft_clear_input(line);
+	*line = history_line;
+	ft_memset(bf, 0, BUFFER_SIZE);
+	ft_putstr(*line);
+}
+
+void	load_next_history_command(t_abs_struct *base, char **line, char *bf)
+{
+	int		fd;
+	char	*history_line;
+
+	if (base->current_history_line >= (base->history_lines - 1))
+	{
+		ft_clear_input(line);
+		ft_memset(bf, 0, BUFFER_SIZE);
+		base->current_history_line = base->history_lines;
+		return ;
+	}
+	fd = ft_open_history(base, O_RDONLY);
+	if (fd < 0)
+		return ;
+	base->current_history_line++;
+	history_line = ft_get_file_line_by_fd(fd, base->current_history_line);
+	close(fd);
+	if (!history_line)
+		return ;
+	ft_clear_input(line);
+	*line = history_line;
+	ft_memset(bf, 0, BUFFER_SIZE);
+	ft_putstr(*line);
+}

--- a/utils/load_history_commands.c
+++ b/utils/load_history_commands.c
@@ -7,10 +7,10 @@ void	load_previous_history_command(t_abs_struct *base, char **line,
 	char	*history_line;
 	char	*tmp;
 
+	ft_memset(bf, 0, BUFFER_SIZE);
 	if (base->current_history_line <= 0)
 	{
 		base->current_history_line = 0;
-		ft_memset(bf, 0, BUFFER_SIZE);
 		return ;
 	}
 	base->current_history_line--;
@@ -27,7 +27,6 @@ void	load_previous_history_command(t_abs_struct *base, char **line,
 		return ;
 	ft_clear_input(line);
 	*line = history_line;
-	ft_memset(bf, 0, BUFFER_SIZE);
 	ft_putstr(*line);
 }
 
@@ -36,10 +35,11 @@ void	load_next_history_command(t_abs_struct *base, char **line, char *bf)
 	int		fd;
 	char	*history_line;
 
+	ft_memset(bf, 0, BUFFER_SIZE);
 	if (base->current_history_line >= (base->history_lines - 1))
 	{
 		ft_clear_input(line);
-		ft_memset(bf, 0, BUFFER_SIZE);
+		*line = ft_strdup("");
 		base->current_history_line = base->history_lines;
 		return ;
 	}
@@ -53,6 +53,5 @@ void	load_next_history_command(t_abs_struct *base, char **line, char *bf)
 		return ;
 	ft_clear_input(line);
 	*line = history_line;
-	ft_memset(bf, 0, BUFFER_SIZE);
 	ft_putstr(*line);
 }

--- a/utils/load_history_commands.c
+++ b/utils/load_history_commands.c
@@ -8,9 +8,12 @@ void	load_previous_history_command(t_abs_struct *base, char **line,
 	char	*tmp;
 
 	if (base->current_history_line <= 0)
+	{
 		base->current_history_line = 0;
-	else
-		base->current_history_line--;
+		ft_memset(bf, 0, BUFFER_SIZE);
+		return ;
+	}
+	base->current_history_line--;
 	fd = ft_open_history(base, O_RDONLY);
 	if (fd < 0)
 		return ;

--- a/utils/process_csi_sequences.c
+++ b/utils/process_csi_sequences.c
@@ -1,0 +1,47 @@
+#include "minishell.h"
+
+static int	is_csi_escape_sequence_complete(char *bf)
+{
+	char *tmp;
+
+	if (ft_strncmp(bf, CSI_ESCAPE, 2))
+		return (0);
+	tmp = bf + 2;
+	while (*tmp >= 0x30 && *tmp <= 0x3F)
+		tmp++;
+	while (*tmp >= 0x20 && *tmp <= 0x2F)
+		tmp++;
+	if (*tmp >= 0x40 && *tmp <= 0x7E)
+		return (1);
+	return (0);
+}
+
+static void	read_csi_escape_sequence(char *bf)
+{
+	int		len;
+
+	len = ft_strlen(bf);
+	while (bf && len < BUFFER_SIZE)
+	{
+		read(STDIN_FILENO, bf + len, 1);
+		if (*(bf + len) >= 0x40 && *(bf + len) <= 0x7E)
+			break;
+		len++;
+	}
+}
+
+int	process_csi_escape_sequence(char *bf, char **line, t_abs_struct *base)
+{
+	if (ft_strncmp(bf, CSI_ESCAPE, 2))
+		return (0);
+	if (!is_csi_escape_sequence_complete(bf))
+		read_csi_escape_sequence(bf);
+	if (!ft_strncmp(bf, ARROW_UP, 3))
+		load_previous_history_command(base, line, bf);
+	else if (!ft_strncmp(bf, ARROW_DOWN, 3))
+		load_next_history_command(base, line, bf);
+	else
+		ft_memset(bf, 0, BUFFER_SIZE);
+	return (1);
+}
+

--- a/utils/process_escape_sequences.c
+++ b/utils/process_escape_sequences.c
@@ -1,8 +1,46 @@
 #include "minishell.h"
 
-void process_escape_sequences(char *bf, char **line, t_abs_struct *base)
+static int	process_control_characters(char *bf, char **line)
 {
-	(void)bf;
-	(void)line;
-	(void)base;
+	if (*bf == CTRL_C)
+	{
+		ft_clear_input(line);
+		ft_putstr("\n");
+		ft_shift_left_bytes(bf, 1);
+		return (1);
+	}
+	else if (*bf == DEL)
+	{
+		ft_borrow_char(ft_strlen(*line), line, bf);
+		ft_shift_left_bytes(bf, 1);
+		return (1);
+	}
+	return (0);
+}
+
+static int	process_fe_escape_sequence(char *bf)
+{
+	if (!bf || *bf != ESCAPE)
+		return (0);
+	if (!(*(bf + 1)))
+		read(STDIN_FILENO, bf + 1, 1);
+	if (*(bf + 1) >= FE_ESCAPE_START && *(bf + 1) <= FE_ESCAPE_END &&
+		ft_strncmp(bf, CSI_ESCAPE, 2))
+	{
+		bf[0] = 0;
+		bf[1] = 0;
+		return (1);
+	}
+	return (0);
+}
+
+int	process_escape_sequences(char *bf, char **line, t_abs_struct *base)
+{
+	if (process_fe_escape_sequence(bf))
+		return (1);
+	if (process_csi_escape_sequence(bf, line, base))
+		return (1);
+	if (process_control_characters(bf, line))
+		return (1);
+	return (0);
 }

--- a/utils/process_escape_sequences.c
+++ b/utils/process_escape_sequences.c
@@ -27,10 +27,8 @@ static int	process_control_characters(char *bf, char **line)
 
 static int	process_fe_escape_sequence(char *bf)
 {
-	if (!bf || *bf != ESCAPE)
+	if (!bf || *bf != ESCAPE || !(*(bf + 1)))
 		return (0);
-	if (!(*(bf + 1)))
-		read(STDIN_FILENO, bf + 1, 1);
 	if (*(bf + 1) >= FE_ESCAPE_START && *(bf + 1) <= FE_ESCAPE_END &&
 		ft_strncmp(bf, CSI_ESCAPE, 2))
 	{

--- a/utils/process_escape_sequences.c
+++ b/utils/process_escape_sequences.c
@@ -1,0 +1,8 @@
+#include "minishell.h"
+
+void process_escape_sequences(char *bf, char **line, t_abs_struct *base)
+{
+	(void)bf;
+	(void)line;
+	(void)base;
+}

--- a/utils/process_escape_sequences.c
+++ b/utils/process_escape_sequences.c
@@ -15,6 +15,11 @@ static int	process_control_characters(char *bf, char **line)
 		ft_shift_left_bytes(bf, 1);
 		return (1);
 	}
+	else if (*bf == ESCAPE)
+	{
+		ft_shift_left_bytes(bf, 1);
+		return (1);
+	}
 	return (0);
 }
 

--- a/utils/process_escape_sequences.c
+++ b/utils/process_escape_sequences.c
@@ -2,22 +2,24 @@
 
 static int	process_control_characters(char *bf, char **line)
 {
+	if (!bf)
+		return (0);
 	if (*bf == CTRL_C)
 	{
 		ft_clear_input(line);
 		ft_putstr("\n");
-		ft_shift_left_bytes(bf, 1);
+		ft_memset(bf, 0, BUFFER_SIZE);
 		return (1);
 	}
 	else if (*bf == DEL)
 	{
 		ft_borrow_char(ft_strlen(*line), line, bf);
-		ft_shift_left_bytes(bf, 1);
+		ft_memset(bf, 0, BUFFER_SIZE);
 		return (1);
 	}
 	else if (*bf == ESCAPE)
 	{
-		ft_shift_left_bytes(bf, 1);
+		ft_memset(bf, 0, BUFFER_SIZE);
 		return (1);
 	}
 	return (0);


### PR DESCRIPTION
Hola Adrián,

En esta PR incluiré algunas correcciones de errores:
* Al borrar sin haber texto de entrada, se metía un espacio
* Al pulsar ctrl+c, escribía el salto de línea pero no se consumía el ctrl +c y este aparecía en el siguiente comando y no se ejecutaba
* Corrección de un leak ya que se hacía un strdup de algo que habíamos hecho un malloc

Procesamiento de teclado:
Ya va mejor pero tenemos algo que no podemos hacer tal como está ahora. Estamos procesando caracter a caracter, sin embargo, tenemos que leer al menos los caracteres de una secuencia de escape. Me intento explicar:

Dado que las secuencias de escape, están formadas por caracteres de la tabla ASCII, para distinguir si es una secuencia de escape o que se han enviado los caracteres de la secuencia de escape por separado, lo que se hace es utilizar un timeout de lectura que se configura a través de c_cc[VTIME] con tcsetattr.
Todas las pulsaciones que se reciban antes del timeout se agrupan y si encontramos una secuencia de escape se supone que esos n caracteres se deben interpretar como la secuencia de escape. Si por el contrario recibimos 1 caracter en cada lectura, tenemos que asumir que se procesan por separado.

Es por lo que he explicado antes, que no se puede procesar caracter a caracter.

He creado un fichero nuevo donde pasaría el procesamiento del teclado que ahora se hace en ft_read_from_keyboard para no tocar lo que está ahora mismo, mientras conseguimos un procesamiento completo correcto.
