### PR TITLE
Corrección de errores, norminette, leaks detectados

### DIFF
--- a/minishell.h
+++ b/minishell.h
@@ -99,6 +99,7 @@ typedef struct s_abs_struct
 	int						counter;
 	int						history_lines;
 	int						current_history_line;
+	char					*last_history_command;
 }							t_abs_struct;
 
 typedef struct s_expand_dollar
@@ -262,6 +263,6 @@ int				process_escape_sequences(char *bf, char **line,
 int				process_csi_escape_sequence(char *bf, char **line,
 					t_abs_struct *base);
 
-t_abs_struct	base;
+t_abs_struct	g_base;
 
 #endif

--- a/minishell.h
+++ b/minishell.h
@@ -247,7 +247,7 @@ void			ft_execute_absolute_shell_command(t_abs_struct *base,
 void			ft_execute_relative_shell_command(t_abs_struct *base,
 					t_process *p);
 int				ft_setlflag(int fd, int set_flag, unsigned int value);
-int				classic_get_next(int fd, char **line);
+int				classic_get_next(int fd, char **line, int clean_buffer);
 int				ft_isascii(int c);
 void			ft_borrow_char(int x, char **line, char *bf);
 

--- a/srcs/ft_init_minishell.c
+++ b/srcs/ft_init_minishell.c
@@ -20,6 +20,10 @@ static void	ft_init_history(t_abs_struct *base)
 	base->history_lines = ft_file_lines_by_fd(fd);
 	if (fd >= 0)
 		close(fd);
+	fd = ft_open_history(base, O_RDONLY);
+	base->last_history_command = ft_get_file_line_by_fd(fd, base->history_lines - 1);
+	if (fd >= 0)
+		close(fd);
 	if (base->history_lines < 0)
 		ft_exit_minishell(base, -1);
 	base->current_history_line = base->history_lines;

--- a/srcs/ft_init_minishell.c
+++ b/srcs/ft_init_minishell.c
@@ -31,10 +31,10 @@ static void	ft_init_history(t_abs_struct *base)
 
 void	process_quit_handler(int sig)
 {
-	extern t_abs_struct	base;
+	extern t_abs_struct	g_base;
 
 	(void)sig;
-	ft_exit_minishell(&base, base.last_executed_process_status);
+	ft_exit_minishell(&g_base, g_base.last_executed_process_status);
 }
 
 int	ft_init_minishell(t_abs_struct *base, char **envp)

--- a/srcs/history.c
+++ b/srcs/history.c
@@ -19,29 +19,33 @@ static void	write_line(char *line)
 	ft_putstr("\n");
 }
 
+static void	free_line(char **line)
+{
+	if (line && *line)
+	{
+		free(*line);
+		*line = 0;
+	}
+}
+
 int	ft_history(t_abs_struct *base)
 {
 	int		fd;
 	char	*line;
+	int		clean_buffer;
 
 	line = 0;
+	clean_buffer = 1;
 	fd = ft_open_history(base, O_RDWR);
 	if (fd <= 0)
 		return (0);
-	while (classic_get_next(fd, &line) > 0)
+	while (classic_get_next(fd, &line, clean_buffer) > 0)
 	{
+		clean_buffer = 0;
 		write_line(line);
-		if (line)
-		{
-			free(line);
-			line = 0;
-		}
+		free_line(&line);
 	}
-	if (line)
-	{
-		free(line);
-		line = 0;
-	}
+	free_line(&line);
 	close(fd);
 	return (1);
 }

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -26,28 +26,28 @@ static int	append_new_line(char **str)
 	return (1);
 }
 
-int	obtain_full_line()
+int	obtain_full_line(void)
 {
-	extern t_abs_struct	base;
+	extern t_abs_struct	g_base;
 	int					found_new_line;
 	char				*trimmed_input;
 
-	if (base.input)
-		free(base.input);
-	base.input = 0;
+	if (g_base.input)
+		free(g_base.input);
+	g_base.input = 0;
 	found_new_line = 0;
-	while (!found_new_line && (!base.input || *base.input))
+	while (!found_new_line && (!g_base.input || *g_base.input))
 	{
-		found_new_line = get_next_line(STDIN_FILENO, &base.input, &base);
+		found_new_line = get_next_line(STDIN_FILENO, &g_base.input, &g_base);
 		if (found_new_line < 0)
-			ft_exit_minishell(&base, 2);
+			ft_exit_minishell(&g_base, 2);
 	}
-	if (base.input && found_new_line && !append_new_line(&base.input))
-		ft_exit_minishell(&base, 1);
-	trimmed_input = ft_trim(base.input);
-	if (ft_strlen(base.input) >= 1 && ft_strcmp(trimmed_input, "\n") \
-			&& ft_isascii(base.input[0]))
-		ft_write_history_line(&base);
+	if (g_base.input && found_new_line && !append_new_line(&g_base.input))
+		ft_exit_minishell(&g_base, 1);
+	trimmed_input = ft_trim(g_base.input);
+	if (ft_strlen(g_base.input) >= 1 && ft_strcmp(trimmed_input, "\n") \
+			&& ft_isascii(g_base.input[0]))
+		ft_write_history_line(&g_base);
 	if (trimmed_input)
 		free(trimmed_input);
 	return (0);
@@ -80,25 +80,25 @@ unsigned int	ft_getlflag(int fd)
 int	main(int argc, char **argv, char **envp)
 {
 	int					minishell_ready;
-	extern t_abs_struct	base;
+	extern t_abs_struct	g_base;
 
 	(void)argc;
 	(void)argv;
-	ft_memset(&base, 0, sizeof(t_abs_struct));
-	minishell_ready = ft_init_minishell(&base, envp);
+	ft_memset(&g_base, 0, sizeof(t_abs_struct));
+	minishell_ready = ft_init_minishell(&g_base, envp);
 	if (minishell_ready)
 		clear_screen();
-	base.c_lflag = ft_getlflag(STDIN_FILENO);
+	g_base.c_lflag = ft_getlflag(STDIN_FILENO);
 	if (!ft_setlflag(STDIN_FILENO, 0, ICANON | ECHO | IEXTEN))
-		ft_exit_minishell(&base, 1);
+		ft_exit_minishell(&g_base, 1);
 	while (minishell_ready)
 	{
-		ft_show_prompt(&base);
+		ft_show_prompt(&g_base);
 		obtain_full_line();
-		execute_command_read(&base);
-		base.first_job = 0;
-		base.num_args = 0;
-		base.parse_string = 0;
+		execute_command_read(&g_base);
+		g_base.first_job = 0;
+		g_base.num_args = 0;
+		g_base.parse_string = 0;
 	}
 	return (0);
 }

--- a/to_do.txt
+++ b/to_do.txt
@@ -16,6 +16,41 @@ comentarios de setenv.c
 43. El fichero de history no lo tratamos y si se mete cualquier cosa rara, va a hacer que el terminal haga cosas raras. Por ejemplo si se mete una secuencia de escape, se imprimirá directamente por pantalla y no quedará desactivada como cuando realizamos la entrada por teclado
 // TODO: modificar el nombre de fichero por ft_setenv.c
 // Problema al solo aceptar dos introducciones con setenv
+44. Encontrado un memory leak. Para reproducir ejecutar los siguientes comandos:
+$ env | grep PWD
+$ CD ..
+# Este comando CD va en mayúsculas
+$ env | grep PWD
+# Este comando con el pipe ya no nos devuelve la salida esperada
+$ env | grep PWD
+# Este comando tampoco nos devuelve la salida esperada
+$ ENV
+# Este comando ENV nos genera el leak. (pego por si no se reproduce el stack trace)
+197==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 103 byte(s) in 2 object(s) allocated from:
+    #0 0x7ffff6ef6b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
+    #1 0x55555555c1df in ft_strdup utils/ft_strdup.c:25
+    #2 0x55555555d577 in ft_array_dup utils/ft_array_dup.c:32
+    #3 0x555555559811 in ft_copy_env srcs/env.c:19
+    #4 0x55555555ac6d in ft_init_minishell srcs/ft_init_minishell.c:51
+    #5 0x555555558561 in main srcs/minishell.c:88
+    #6 0x7ffff6a48bf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)
+
+Direct leak of 50 byte(s) in 1 object(s) allocated from:
+    #0 0x7ffff6ef6b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
+    #1 0x55555555c4e0 in ft_strjoin utils/ft_strjoin.c:42
+    #2 0x555555562e51 in ft_array_update utils/ft_array_update.c:32
+    #3 0x555555558f2d in ft_aux_function srcs/cd.c:45
+    #4 0x555555559384 in cd srcs/cd.c:85
+    #5 0x555555561582 in execute_environment_builtins2 utils/ft_execute_builtin.c:57
+    #6 0x5555555618f5 in ft_execute_builtin utils/ft_execute_builtin.c:102
+    #7 0x55555555f885 in ft_launch_job utils/ft_launch_job.c:51
+    #8 0x555555558305 in execute_command_read srcs/minishell.c:61
+    #9 0x5555555585c7 in main srcs/minishell.c:98
+    #10 0x7ffff6a48bf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)
+
+SUMMARY: AddressSanitizer: 153 byte(s) leaked in 3 allocation(s).
 
 /*Existe un problema al crear al crear más memoria y copiar lo necesario*/
 

--- a/utils/ft_classic_get_next.c
+++ b/utils/ft_classic_get_next.c
@@ -76,7 +76,7 @@ static	int	end(char **stat, char **line, int i, int fd)
 		return (finalline(&stat[fd], line));
 }
 
-int	classic_get_next(int fd, char **line)
+int	classic_get_next(int fd, char **line, int clean_buffer)
 {
 	static char		*stat[2048];
 	char			buff[BUFFER_SIZE + 1];
@@ -89,8 +89,12 @@ int	classic_get_next(int fd, char **line)
 	while (i > 0)
 	{
 		buff[i] = '\0';
-		if (stat[fd] == NULL)
+		if (stat[fd] == NULL || clean_buffer)
+		{
+			if (clean_buffer)
+				free(stat[fd]);
 			stat[fd] = ft_strdup(buff);
+		}
 		else
 		{
 			temp = ft_strjoin(stat[fd], buff);

--- a/utils/ft_classic_get_next.c
+++ b/utils/ft_classic_get_next.c
@@ -103,6 +103,7 @@ int	classic_get_next(int fd, char **line, int clean_buffer)
 		}
 		if (ft_strchr(stat[fd], '\n'))
 			break ;
+		i = read(fd, buff, BUFFER_SIZE);
 	}
 	return (end(stat, line, i, fd));
 }

--- a/utils/ft_classic_get_next.c
+++ b/utils/ft_classic_get_next.c
@@ -76,11 +76,28 @@ static	int	end(char **stat, char **line, int i, int fd)
 		return (finalline(&stat[fd], line));
 }
 
+static void	assign_buffer_to_stat(char *buff, char **stat, int clean_buffer)
+{
+	char	*temp;
+
+	if (*stat == NULL || clean_buffer)
+	{
+		if (clean_buffer && *stat != NULL)
+			free(*stat);
+		*stat = ft_strdup(buff);
+	}
+	else
+	{
+		temp = ft_strjoin(*stat, buff);
+		free(*stat);
+		*stat = temp;
+	}
+}
+
 int	classic_get_next(int fd, char **line, int clean_buffer)
 {
 	static char		*stat[2048];
 	char			buff[BUFFER_SIZE + 1];
-	char			*temp;
 	int				i;
 
 	if (fd < 0 || line == NULL || BUFFER_SIZE < 1 || read(fd, buff, 0) < 0)
@@ -89,18 +106,8 @@ int	classic_get_next(int fd, char **line, int clean_buffer)
 	while (i > 0)
 	{
 		buff[i] = '\0';
-		if (stat[fd] == NULL || clean_buffer)
-		{
-			if (clean_buffer)
-				free(stat[fd]);
-			stat[fd] = ft_strdup(buff);
-		}
-		else
-		{
-			temp = ft_strjoin(stat[fd], buff);
-			free(stat[fd]);
-			stat[fd] = temp;
-		}
+		assign_buffer_to_stat(buff, &stat[fd], clean_buffer);
+		clean_buffer = 0;
 		if (ft_strchr(stat[fd], '\n'))
 			break ;
 		i = read(fd, buff, BUFFER_SIZE);

--- a/utils/ft_file_lines.c
+++ b/utils/ft_file_lines.c
@@ -27,7 +27,7 @@ int	ft_file_lines_by_fd(int fd)
 	while (read_ok > 0)
 	{
 		read_ok = read(fd, &c, 1);
-		if (read_ok < 0)
+		if (read_ok <= 0)
 			break ;
 		line_with_content = 1;
 		if (c == '\n')

--- a/utils/ft_get_file_line.c
+++ b/utils/ft_get_file_line.c
@@ -26,14 +26,17 @@ char	*ft_get_file_line_by_fd(int fd, int line)
 	char	*str;
 	int		curr_line;
 	int		found_nl;
+	int		clean_buffer;
 
 	if (fd < 0)
 		return (0);
 	curr_line = 0;
 	str = 0;
+	clean_buffer = 1;
 	while (curr_line <= line)
 	{
-		found_nl = classic_get_next(fd, &str);
+		found_nl = classic_get_next(fd, &str, clean_buffer);
+		clean_buffer = 0;
 		if (found_nl < 1)
 			break ;
 		reset_str(curr_line, line, &str);

--- a/utils/ft_release_base.c
+++ b/utils/ft_release_base.c
@@ -20,6 +20,8 @@ void	ft_release_base(t_abs_struct *base)
 		free(base->input);
 	ft_array_release(base->env);
 	base->parse_string = 0;
+	if (base->last_history_command)
+		free(base->last_history_command);
 	ft_release_jobs(base->first_job);
 	base->first_job = 0;
 	return ;

--- a/utils/ft_set_default_signals.c
+++ b/utils/ft_set_default_signals.c
@@ -14,41 +14,11 @@
 
 static int	set_signals_1(void)
 {
-/* 	if (signal(SIGINT, SIG_DFL) == SIG_ERR)
-	{
-		ft_putstr_fd(strerror(errno), STDERR_FILENO);
-		return (errno);
-	}
-	if (signal(SIGQUIT, SIG_DFL) == SIG_ERR)
-	{
-		ft_putstr_fd(strerror(errno), STDERR_FILENO);
-		return (errno);
-	}
-	if (signal(SIGTSTP, SIG_DFL) == SIG_ERR)
-	{
-		ft_putstr_fd(strerror(errno), STDERR_FILENO);
-		return (errno);
-	} */
 	return (0);
 }
 
 static int	set_signals_2(void)
 {
-/* 	if (signal(SIGTTIN, SIG_DFL) == SIG_ERR)
-	{
-		ft_putstr_fd(strerror(errno), STDERR_FILENO);
-		return (errno);
-	}
-	if (signal(SIGTTOU, SIG_DFL) == SIG_ERR)
-	{
-		ft_putstr_fd(strerror(errno), STDERR_FILENO);
-		return (errno);
-	}
-	if (signal(SIGCHLD, SIG_DFL) == SIG_ERR)
-	{
-		ft_putstr_fd(strerror(errno), STDERR_FILENO);
-		return (errno);
-	} */
 	return (0);
 }
 
@@ -67,11 +37,11 @@ int	ft_set_default_signals(void)
 
 void	forked_process_signal_handler(int sig)
 {
-	extern t_abs_struct	base;
+	extern t_abs_struct	g_base;
 
 	if (sig == SIGINT)
 	{
 		ft_putstr("\e[0m\n    Esto ha terminado con ctrl+c    \n");
-		ft_exit_minishell(&base, base.last_executed_process_status);
+		ft_exit_minishell(&g_base, g_base.last_executed_process_status);
 	}
 }

--- a/utils/ft_write_history_line.c
+++ b/utils/ft_write_history_line.c
@@ -12,13 +12,14 @@
 
 #include "minishell.h"
 
+// Same command won't be registered twice in a row
 void	ft_write_history_line(t_abs_struct *base)
 {
 	int	fd;
 
 	if (base->last_history_command != 0
 		&& !ft_strcmp(base->last_history_command, base->input))
-		return ; // Same command won't be registered twice in a row
+		return ;
 	if (base->last_history_command)
 		free(base->last_history_command);
 	base->last_history_command = ft_strdup(base->input);

--- a/utils/ft_write_history_line.c
+++ b/utils/ft_write_history_line.c
@@ -16,6 +16,12 @@ void	ft_write_history_line(t_abs_struct *base)
 {
 	int	fd;
 
+	if (base->last_history_command != 0
+		&& !ft_strcmp(base->last_history_command, base->input))
+		return ; // Same command won't be registered twice in a row
+	if (base->last_history_command)
+		free(base->last_history_command);
+	base->last_history_command = ft_strdup(base->input);
 	fd = ft_open_history(base, O_RDWR | O_APPEND);
 	if (fd < 0)
 		return ;

--- a/utils/load_history_commands.c
+++ b/utils/load_history_commands.c
@@ -36,7 +36,7 @@ void	load_next_history_command(t_abs_struct *base, char **line, char *bf)
 	char	*history_line;
 
 	ft_memset(bf, 0, BUFFER_SIZE);
-	if (base->current_history_line >= (base->history_lines - 1))
+	if (base->current_history_line >= (base->history_lines))
 	{
 		ft_clear_input(line);
 		*line = ft_strdup("");


### PR DESCRIPTION
Buenas Adrián,

En esta PR irán cosas para afinar el history:
* Ya no hay que hacer más de un clic para avanzar/retroceder (era problema del buffer del gnl, he añadido un flag para limpiar el buffer)
* Eliminadas repeticiones del fichero history. No se registraran n comandos consecutivos, iguales.

Correcciones de norminette

Actuailización del fichero todo con un par de leaks directos detectados. Con el stack trace debe ser fácil de corregir pero ahora no tengo tiempo