### PR TITLE
Release candidate 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ test:	${OBJS}
 	@gcc ${OBJS} && ./a.out
 
 debug:	${OBJS}
-	${CC} -o ${NAME} ${CFLAGS_DEBUG} ${OBJS}
+	${CC} -o ${NAME} ${CFLAGS_DEBUG} ${OBJS} -lncurses
 
 re: fclean all
 

--- a/minishell.h
+++ b/minishell.h
@@ -102,6 +102,7 @@ typedef struct s_abs_struct
 	char					*arrow_up;
 	char					*arrow_down;
 	t_job					*first_job;
+	t_process				*current_process;
 	unsigned int			c_lflag;
 	int						counter;
 	int						history_lines;

--- a/srcs/ft_init_minishell.c
+++ b/srcs/ft_init_minishell.c
@@ -16,7 +16,7 @@ int	ft_init_minishell(t_abs_struct *base, char **envp)
 {
 	char	termbuf[2048];
 	char	*capbuf;
-	
+
 	tgetent(termbuf, "xterm-256color");
 	signal(SIGQUIT, signal_handler);
 	if (!base)
@@ -24,7 +24,10 @@ int	ft_init_minishell(t_abs_struct *base, char **envp)
 	ft_memset(base, 0, sizeof(t_abs_struct));
 	ft_copy_env(base, envp);
 	ft_init_history(base);
+	capbuf = 0;
 	base->arrow_up = tgetstr("ku", &capbuf);
 	base->arrow_down = tgetstr("kd", &capbuf);
+	if (capbuf)
+		free(capbuf);
 	return (1);
 }

--- a/srcs/ft_init_minishell.c
+++ b/srcs/ft_init_minishell.c
@@ -12,16 +12,34 @@
 
 #include "minishell.h"
 
+static unsigned int	ft_getlflag(int fd)
+{
+	struct termios	settings;
+	unsigned int	result;
+
+	if (tcgetattr (fd, &settings) < 0)
+	{
+		perror ("error in tcgetattr");
+		return (0);
+	}
+	result = settings.c_lflag;
+	return (result);
+}
+
 int	ft_init_minishell(t_abs_struct *base, char **envp)
 {
 	char	termbuf[2048];
 	char	*capbuf;
 
-	tgetent(termbuf, "xterm-256color");
-	signal(SIGQUIT, signal_handler);
 	if (!base)
 		return (0);
 	ft_memset(base, 0, sizeof(t_abs_struct));
+	if (signal(SIGQUIT, signal_handler) == SIG_ERR)
+		ft_exit_minishell(1);
+	base->c_lflag = ft_getlflag(STDIN_FILENO);
+	if (!ft_setlflag(STDIN_FILENO, 0, ICANON | ECHO | IEXTEN))
+		ft_exit_minishell(1);
+	tgetent(termbuf, "xterm-256color");
 	ft_copy_env(base, envp);
 	ft_init_history(base);
 	capbuf = 0;

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -67,20 +67,6 @@ static void	execute_command_read(t_abs_struct *base)
 		ft_exit_minishell(1);
 }
 
-unsigned int	ft_getlflag(int fd)
-{
-	struct termios	settings;
-	unsigned int	result;
-
-	if (tcgetattr (fd, &settings) < 0)
-	{
-		perror ("error in tcgetattr");
-		return (0);
-	}
-	result = settings.c_lflag;
-	return (result);
-}
-
 int	main(int argc, char **argv, char **envp)
 {
 	int					minishell_ready;
@@ -92,9 +78,6 @@ int	main(int argc, char **argv, char **envp)
 	minishell_ready = ft_init_minishell(&g_base, envp);
 	if (minishell_ready)
 		ft_clear_screen();
-	g_base.c_lflag = ft_getlflag(STDIN_FILENO);
-	if (!ft_setlflag(STDIN_FILENO, 0, ICANON | ECHO | IEXTEN))
-		ft_exit_minishell(1);
 	signal(SIGINT, signal_handler);
 	signal(SIGQUIT, signal_handler);
 	while (minishell_ready)

--- a/srcs/setenv.c
+++ b/srcs/setenv.c
@@ -120,7 +120,7 @@ int	ft_setenv(t_abs_struct *base, t_process *p)
 
 	ret = 0;
 	key_value = ft_split(p->argv[1], '=');
-	if (key_value)
+	if (key_value && *key_value)
 	{
 		if (ft_search_env(base->env, key_value[0]))
 			ft_unset(base, p);
@@ -133,6 +133,8 @@ int	ft_setenv(t_abs_struct *base, t_process *p)
 			free(tri);
 		return (ret);
 	}
+	if (key_value)
+		ft_array_release(key_value);
 	ft_putstr("\e[0mError en los argumentos\n");
 	base->error = 0;
 	return (0);

--- a/srcs/signals.c
+++ b/srcs/signals.c
@@ -34,12 +34,16 @@ void	signal_handler(int sig)
 
 void	forked_process_signal_handler(int sig)
 {
+	extern t_abs_struct	g_base;
+
 	if (sig == SIGINT || sig == SIGQUIT)
 	{
-		if (sig == SIGINT)
+		if (sig == SIGINT){
 			ft_putstr("\n");
-		else if (sig == SIGQUIT)
+		}
+		else if (sig == SIGQUIT) {
 			ft_putstr("Abandona (`core' generado)\n");
-		exit(128 + sig);
+		}
+		g_base.current_process->status = 128 + sig;
 	}
 }

--- a/utils/ft_execute_absolute_shell_command.c
+++ b/utils/ft_execute_absolute_shell_command.c
@@ -12,9 +12,24 @@
 
 #include "minishell.h"
 
+// This function will check syntax
+static int	check_command_syntax(char **argv)
+{
+	if (!argv || !(*argv))
+		return (0);
+	if (ft_strchr(*argv, '>') || ft_strchr(*argv, '<'))
+	{
+		ft_putstr("Syntatic error in command");
+		return (0);
+	}
+	return (1);
+}
+
 void	ft_execute_absolute_shell_command(t_abs_struct *base,
 	char *cmd, t_process *p)
 {
+	if (!check_command_syntax(p->argv))
+		return ;
 	execve(cmd, p->argv, base->env);
 	if (errno == EACCES)
 		p->status = 126;

--- a/utils/ft_expand_process_cmd_utils.c
+++ b/utils/ft_expand_process_cmd_utils.c
@@ -37,7 +37,7 @@ char	*ft_extract_variable_name(char **cmd)
 		return (0);
 	tmp = *cmd;
 	while (*cmd && !ft_isspace(**cmd) && **cmd != '"' && **cmd != '\'' \
-				 && **cmd != '$' && **cmd != ':' && (**cmd))
+				 && **cmd != '$' && **cmd != ':' && **cmd != '=' && (**cmd))
 		(*cmd)++;
 	ret = ft_calloc(*cmd - tmp + 1, sizeof(char));
 	if (!(ret))

--- a/utils/ft_extract_redirections_from_argv.c
+++ b/utils/ft_extract_redirections_from_argv.c
@@ -45,7 +45,9 @@ int	ft_extract_redirections_from_argv(t_process *p)
 	char	**i;
 	int		redirs_len;
 
-	i = p->argv;
+	if (!p || !p->argv)
+		return (0);
+	i = p->argv + 1;
 	redirs_len = 0;
 	while (*i)
 	{

--- a/utils/ft_launch_job.c
+++ b/utils/ft_launch_job.c
@@ -56,6 +56,7 @@ void	ft_launch_job(t_abs_struct *base, t_job *j)
 	current = j->first_process;
 	while (current)
 	{
+		base->current_process = current;
 		ft_expand_process_cmd(base, current);
 		ft_configure_pipes(current);
 		if (!ft_execute_builtin(base, previous, current))


### PR DESCRIPTION
Corregidos fallos detectados en tus pruebas
Corregido un fallo detectado durante mis pruebas: export a=a; export $a=b (no realizaba la expansión de $a)
Pendiente de pasar norminette
Pendiente de corregir las redirecciones para los builtins (no se por qué no está funcionando por ejemplo echo "a" >> prueba)