### PR TITLE
 Corregidas redirecciones:

### DIFF
--- a/minishell.h
+++ b/minishell.h
@@ -190,11 +190,14 @@ t_job			*ft_build_job_ctrl_d(void);
 t_process		*ft_build_processes(char *expanded_cmd);
 t_process		*ft_build_ctrl_d_process(void);
 t_process		*ft_build_process(char *expanded_cmd);
-int				set_redirections(t_abs_struct *base, t_process *p);
+int				set_redirections(t_abs_struct *base, t_process *p,
+					int files_must_exist);
 int				ft_output_add_redirection(t_abs_struct *base, char *redir, \
-				int *redirected);
-int				ft_output_redirection(char *redir, int *redirected);
-int				ft_input_redirection(char *redir, int *redirected);
+					int *redirected, int files_must_exist);
+int				ft_output_redirection(char *redir, int *redirected,
+					int files_must_exist);
+int				ft_input_redirection(char *redir, int *redirected,
+					int files_must_exist);
 void			ft_set_pipes(t_process *previous, t_process *current);
 void			ft_close_pipes(t_process *previous, t_process *current);
 void			ft_configure_pipes(t_process *current);

--- a/srcs/ft_init_minishell.c
+++ b/srcs/ft_init_minishell.c
@@ -47,5 +47,8 @@ int	ft_init_minishell(t_abs_struct *base, char **envp)
 	base->arrow_down = tgetstr("kd", &capbuf);
 	if (capbuf)
 		free(capbuf);
+	base->std_fds.infile = -1;
+	base->std_fds.outfile = -1;
+	base->std_fds.errfile = -1;
 	return (1);
 }

--- a/utils/ft_execute_builtin.c
+++ b/utils/ft_execute_builtin.c
@@ -21,6 +21,8 @@ static int	execute_environment_builtins(t_abs_struct *base,
 	base->parse_string = p->argv;
 	if (!ft_strcmp(p->argv[0], "env"))
 	{
+		if (set_redirections(base, p, 1) < 0)
+			return (0);
 		ft_set_pipes(previous, p);
 		ft_env(base);
 	}
@@ -54,12 +56,16 @@ static int	execute_environment_builtins2(t_abs_struct *base,
 		launch_exit_builtin(p->argv[1]);
 	else if (!ft_strcmp(p->argv[0], "echo"))
 	{
+		if (set_redirections(base, p, 1) < 0)
+			return (0);
 		ft_set_pipes(previous, p);
 		ft_echo(base, p);
 		return (1);
 	}
 	else if (!ft_strcmp(p->argv[0], "pwd"))
 	{
+		if (set_redirections(base, p, 1) < 0)
+			return (0);
 		ft_set_pipes(previous, p);
 		ft_pwd();
 		return (1);
@@ -98,6 +104,8 @@ static int	execute_environment_builtins3(t_process *previous, t_process *p,
 int	ft_execute_builtin(t_abs_struct *base, t_process *previous,
 	t_process *p)
 {
+	int		executed;
+
 	ft_putstr("\e[0m");
 	if (!p->argv || !*p->argv)
 	{
@@ -107,11 +115,11 @@ int	ft_execute_builtin(t_abs_struct *base, t_process *previous,
 	}
 	base->parse_string = p->argv;
 	base->a = 0;
-	if (execute_environment_builtins(base, previous, p))
-		return (1);
-	if (execute_environment_builtins2(base, previous, p))
-		return (1);
-	if (execute_environment_builtins3(previous, p, base))
-		return (1);
-	return (0);
+	executed = execute_environment_builtins(base, previous, p);
+	if (!executed)
+		executed = execute_environment_builtins2(base, previous, p);
+	if (!executed)
+		executed = execute_environment_builtins3(previous, p, base);
+	restore_std_fds(&base->std_fds);
+	return (executed);
 }

--- a/utils/ft_input_redirection.c
+++ b/utils/ft_input_redirection.c
@@ -12,11 +12,12 @@
 
 #include "minishell.h"
 
-static int	apply_input_redirection(int i_fd,
-	char *right_side)
+static int	apply_input_redirection(int i_fd, char *right_side,
+				int file_must_exist)
 {
 	int			o_fd;
 	char		*fd_file;
+	int			flags;
 
 	fd_file = ft_trim(right_side);
 	if (!fd_file)
@@ -27,7 +28,10 @@ static int	apply_input_redirection(int i_fd,
 		close(i_fd);
 		return (1);
 	}
-	o_fd = ft_get_redirection_fd(fd_file, O_RDONLY, 0666, -1);
+	flags = O_CREAT | O_RDONLY;
+	if (file_must_exist)
+		flags = O_RDONLY;
+	o_fd = ft_get_redirection_fd(fd_file, flags, 0666, -1);
 	if (o_fd < 0)
 	{
 		free(fd_file);
@@ -44,14 +48,14 @@ static void	dup_stdin_and_close_it(int i_fd)
 {
 	extern t_abs_struct	g_base;
 
-	if (i_fd != STDIN_FILENO)
+	if (i_fd == STDIN_FILENO)
 	{
 		g_base.std_fds.infile = dup(STDIN_FILENO);
 		close(STDIN_FILENO);
 	}
 }
 
-int	ft_input_redirection(char *redir, int *redirected)
+int	ft_input_redirection(char *redir, int *redirected, int file_must_exist)
 {
 	char			*fd;
 	int				i_fd;
@@ -69,7 +73,8 @@ int	ft_input_redirection(char *redir, int *redirected)
 		else
 		{
 			dup_stdin_and_close_it(i_fd);
-			*redirected = apply_input_redirection(i_fd, redir);
+			*redirected = apply_input_redirection(i_fd, redir,
+				file_must_exist);
 		}
 		found_redirection = 1;
 	}

--- a/utils/ft_launch_job.c
+++ b/utils/ft_launch_job.c
@@ -29,7 +29,12 @@ static void	ft_fork_child(t_abs_struct *base, t_process *previous,
 	pid = fork();
 	if (pid == 0)
 	{
-		set_redirections(base, current);
+		if (set_redirections(base, current, 1) < 0)
+		{
+			current->status = 1;
+			restore_std_fds(&base->std_fds);
+			exit(current->status);
+		}
 		ft_set_pipes(previous, current);
 		ft_launch_process(base, current);
 		exit(current->status);

--- a/utils/ft_output_add_redirection.c
+++ b/utils/ft_output_add_redirection.c
@@ -12,11 +12,14 @@
 
 #include "minishell.h"
 
-static int	apply_output_add_redirection(int i_fd, char *right_side)
+static int	apply_output_add_redirection(int i_fd, char *right_side,
+				int files_must_exist)
 {
 	int			o_fd;
 	char		*fd_file;
+	int			flags;
 
+	(void)files_must_exist;
 	fd_file = ft_trim(right_side);
 	if (!fd_file)
 		return (0);
@@ -26,8 +29,8 @@ static int	apply_output_add_redirection(int i_fd, char *right_side)
 		close(i_fd);
 		return (1);
 	}
-	o_fd = ft_get_redirection_fd(fd_file, O_CREAT | O_TRUNC | O_WRONLY,
-			0666, -1);
+	flags = O_APPEND | O_CREAT | O_WRONLY;
+	o_fd = ft_get_redirection_fd(fd_file, flags, 0666, -1);
 	if (o_fd < 0)
 	{
 		free(fd_file);
@@ -40,7 +43,8 @@ static int	apply_output_add_redirection(int i_fd, char *right_side)
 	return (1);
 }
 
-int	ft_output_add_redirection(t_abs_struct *base, char *redir, int *redirected)
+int	ft_output_add_redirection(t_abs_struct *base, char *redir, int *redirected
+		, int files_must_exist)
 {
 	char		*fd;
 	int			i_fd;
@@ -54,12 +58,12 @@ int	ft_output_add_redirection(t_abs_struct *base, char *redir, int *redirected)
 		i_fd = ft_get_fd(fd, STDOUT_FILENO);
 		if (i_fd >= 0)
 		{
-			if (i_fd != STDOUT_FILENO)
+			if (i_fd == STDOUT_FILENO)
 			{
 				base->std_fds.outfile = dup(STDOUT_FILENO);
 				close(STDOUT_FILENO);
 			}
-			*redirected = apply_output_add_redirection(i_fd, redir);
+			*redirected = apply_output_add_redirection(i_fd, redir, files_must_exist);
 		}
 		found_redirection = 1;
 	}

--- a/utils/ft_output_redirection.c
+++ b/utils/ft_output_redirection.c
@@ -28,11 +28,14 @@ void	redirect_to_exit(int o_fd, int i_fd)
 		ft_exit_minishell(errno);
 }
 
-static int	apply_output_redirection(int i_fd, char *right_side)
+static int	apply_output_redirection(int i_fd, char *right_side,
+				int files_must_exist)
 {
 	int			o_fd;
 	char		*fd_file;
+	int			flags;
 
+	(void)files_must_exist;
 	fd_file = ft_trim(right_side);
 	if (!fd_file)
 		return (0);
@@ -42,8 +45,8 @@ static int	apply_output_redirection(int i_fd, char *right_side)
 		close(i_fd);
 		return (1);
 	}
-	o_fd = ft_get_redirection_fd(fd_file, O_CREAT | O_TRUNC | O_WRONLY, 0666,
-			-1);
+	flags = O_CREAT | O_TRUNC | O_WRONLY;
+	o_fd = ft_get_redirection_fd(fd_file, flags, 0666, -1);
 	if (o_fd < 0)
 	{
 		free(fd_file);
@@ -60,14 +63,14 @@ static void	dup_stdout_and_close_it(int i_fd)
 {
 	extern t_abs_struct		g_base;
 
-	if (i_fd != STDOUT_FILENO)
+	if (i_fd == STDOUT_FILENO)
 	{
 		g_base.std_fds.outfile = dup(STDOUT_FILENO);
 		close(STDOUT_FILENO);
 	}
 }
 
-int	ft_output_redirection(char *redir, int *redirected)
+int	ft_output_redirection(char *redir, int *redirected, int files_must_exist)
 {
 	char		*fd;
 	int			i_fd;
@@ -84,7 +87,8 @@ int	ft_output_redirection(char *redir, int *redirected)
 		if (i_fd >= 0)
 		{
 			dup_stdout_and_close_it(i_fd);
-			*redirected = apply_output_redirection(i_fd, redir);
+			*redirected = apply_output_redirection(i_fd, redir,
+				files_must_exist);
 		}
 		found_redirection = 1;
 	}

--- a/utils/redirections.c
+++ b/utils/redirections.c
@@ -12,24 +12,35 @@
 
 #include "minishell.h"
 
-static int	set_redirection(t_abs_struct *base, char *i)
+static int	set_redirection(t_abs_struct *base, char *i, int files_must_exist)
 {
 	int		redirected;
+	int		found_redirection;
 
+	found_redirection = 0;
 	redirected = 0;
-	if (ft_output_add_redirection(base, i, &redirected))
-		return (redirected);
-	if (ft_output_redirection(i, &redirected))
-		return (redirected);
-	if (ft_input_redirection(i, &redirected))
-		return (redirected);
+	if (ft_output_add_redirection(base, i, &redirected, files_must_exist))
+		found_redirection = 1;
+	if (!found_redirection && ft_output_redirection(i, &redirected,
+		files_must_exist))
+		found_redirection = 1;
+	if (!found_redirection && ft_input_redirection(i, &redirected, files_must_exist))
+		found_redirection = 1;
+	if (found_redirection)
+	{
+		if (redirected)
+			return (redirected);
+		else
+			return (-1);
+	}
 	return (0);
 }
 
-int	set_redirections(t_abs_struct *base, t_process *p)
+int	set_redirections(t_abs_struct *base, t_process *p, int files_must_exist)
 {
 	char	**i;
 	int		redirected;
+	int		redirOk;
 
 	if (!p || !p->argv || !ft_extract_redirections_from_argv(p))
 		return (1);
@@ -37,7 +48,13 @@ int	set_redirections(t_abs_struct *base, t_process *p)
 	redirected = 0;
 	while (i && *i)
 	{
-		if (set_redirection(base, *i))
+		redirOk = set_redirection(base, *i, files_must_exist);
+		if (redirOk < 0)
+		{
+			ft_putstr("Error en la redirección\n");
+			return (-1);
+		}
+		else if (redirOk > 0)
 			redirected = 1;
 		i++;
 	}


### PR DESCRIPTION
$ ls < ls > ls -> no muestra el mensaje tal cual de bash pero da un error de redirección
$ pwd > test
$ pwd >> test_add
$ cat < test > test_add
$ cat < test >> test_add