### PR TITLE
Corrección de export

### DIFF
--- a/minishell.h
+++ b/minishell.h
@@ -151,6 +151,7 @@ int				assign_to_fd_helper(char c);
 void			redirect_to_exit(int o_fd, int i_fd);
 char			*ft_strdup(const char *s1);
 char			*ft_strchr(const char *s, int c);
+char			**ft_strstr_in_array(const char **array, char *tgt);
 char			*ft_strstr(const char *s, char *tgt);
 char			*ft_strcdup(const char *s1, int c);
 int				get_next_line(int fd, char **line, t_abs_struct *base);
@@ -159,6 +160,7 @@ void			ft_shift_left(char *bf);
 void			ft_shift_left_bytes(char *bf, int bytes);
 char			*ft_strjoin(char const *s1, char const *s2);
 char			**ft_split(char const *s, char c);
+char			**ft_split_key_value_pair(char const *s, char c);
 void			ft_putstr(char *s);
 void			ft_putnstr(char *s, size_t len);
 void			ft_putnbr(int n);
@@ -177,10 +179,10 @@ void			load_previous_history_command(t_abs_struct *base, char **line,
 void			load_next_history_command(t_abs_struct *base, char **line,
 					char *bf);
 int				ft_pwd(void);
-int				ft_export(t_abs_struct *base, t_process *p);
+void			ft_export(t_abs_struct *base, t_process *p);
 int				ft_copy_env(t_abs_struct *base, char **envp);
 int				ft_env(t_abs_struct *base);
-int				ft_setenv(t_abs_struct *base, t_process *p);
+int				ft_setenv(t_abs_struct *base, char *arg);
 void			ft_exit_minishell(int exit_code);
 int				ft_unset(t_abs_struct *base, t_process *p);
 int				ft_help(void);
@@ -234,6 +236,7 @@ size_t			ft_strnlen(const char *s, size_t max);
 int				ft_memcmp(const void *s1, const void *s2, size_t n);
 void			*ft_memcpy(void *dest, const void *src, size_t n);
 int				ft_array_add(char ***array, int *array_len, char *value);
+int				ft_array_delete_pos(char ***array, int *array_len, int pos);
 int				field_contains_redirs(char *field);
 int				ft_array_update(char ***array, int *array_len, char *key,
 					char *value);
@@ -243,7 +246,9 @@ char			**ft_array_dup_without(char **env, size_t len_env,
 void			ft_array_release(char **envp);
 size_t			ft_array_len(char **envp);
 void			ft_array_slide_left(char **array);
+int				is_env_valid_argument(char *arg);
 char			*ft_getenv(char **env, char *key);
+int				ft_search_env(char **env, char *key);
 char			*expand_env_value(char **envp, char *env_value);
 size_t			ft_strlen(const char *s);
 int				ft_strncmp(const char *s1, const char *s2, size_t n);
@@ -261,6 +266,7 @@ char			*ft_split_shell_by(char **str, char *separator);
 char			*ft_split_shell_process(char **str);
 int				check_base_syntatic_errors(char *cmd);
 char			*get_first_non_empty_arg(char **args);
+char			**get_first_non_empty_arg_pos(char **args);
 int				ft_isinteger(char *str);
 int				ft_count_until_separator(char **str, int actual_arg);
 void			ft_remove_quotes(char *field);
@@ -291,7 +297,8 @@ int				process_csi_escape_sequence(char *bf, char **line,
 void			ft_update_environment_pwds(char *old_pwd, char *pwd);
 int				ft_get_first_fd_available_between(int minimum, int maximum);
 char			*ft_strtrim(char const *s1, char const *set);
-
+void			ft_delete_existing_key(t_abs_struct *base, char *key);
+char			*expand(t_abs_struct *base, char *cmd);
 t_abs_struct	g_base;
 
 #endif

--- a/srcs/env.c
+++ b/srcs/env.c
@@ -36,41 +36,40 @@ int	ft_env(t_abs_struct *base)
 	return (1);
 }
 
-static char	*ft_get_env_to_unset(t_abs_struct *base, t_process *p)
-{
-	char	*env;
-	char	**key_value;
-
-	if (!base->env || !p || !p->argv || !p->argv[0] || !p->argv[1])
-		return (0);
-	key_value = ft_split(p->argv[1], '=');
-	env = ft_getenv(base->env, key_value[0]);
-	if (!key_value || !(env))
-	{
-		ft_array_release(key_value);
-		return (0);
-	}
-	ft_array_release(key_value);
-	return (env);
-}
-
 int	ft_unset(t_abs_struct *base, t_process *p)
 {
-	char	**it_new;
-	char	*env;
+	char	**argv;
+	int		keypos;
 
-	env = ft_get_env_to_unset(base, p);
-	if (!(env))
+	if (ft_array_len(p->argv) == 1)
 		return (1);
-	it_new = ft_array_dup_without(base->env, base->lines_envp, env);
-	if (it_new)
+	argv = p->argv + 1;
+	while (argv && *argv)
 	{
-		free(base->env);
-		base->env = it_new;
-		base->lines_envp--;
+		if (!is_env_valid_argument(*argv))
+		{
+			ft_putstr_fd("Identificador no válido\n", STDERR_FILENO);
+			p->status = 1;
+			return (1);
+		}
+		else if (ft_strlen(*argv))
+		{
+			keypos = ft_search_env(base->env, *argv);
+			if (keypos >= 0
+				&& !ft_array_delete_pos(&base->env, &base->lines_envp, keypos))
+				ft_exit_minishell(1);
+		}
+		argv++;
 	}
-	free(env);
-	if (it_new)
-		return (1);
-	return (0);
+	return (1);
+}
+
+void	ft_delete_existing_key(t_abs_struct *base, char *key)
+{
+	int	key_pos;
+
+	key_pos = ft_search_env(base->env, key);
+	if (key_pos >= 0
+		&& !ft_array_delete_pos(&base->env, &base->lines_envp, key_pos))
+		ft_exit_minishell(1);
 }

--- a/srcs/ft_export.c
+++ b/srcs/ft_export.c
@@ -45,10 +45,27 @@ static int	ft_print_declares(t_abs_struct *base)
 	return (1);
 }
 
-int	ft_export(t_abs_struct *base, t_process *p)
+void	ft_export(t_abs_struct *base, t_process *p)
 {
-	if (!p->argv[1])
-		return (ft_print_declares(base));
+	char	*first_non_empty;
+	char	**args;
+
+	p->status = 0;
+	first_non_empty = get_first_non_empty_arg(p->argv + 1);
+	if (!first_non_empty)
+		ft_print_declares(base);
 	else
-		return (ft_setenv(base, p));
+	{
+		args = p->argv + 1;
+		while (args && *args)
+		{
+			if (!ft_setenv(base, *args))
+			{
+				p->status = 1;
+				ft_putstr_fd("Identificador no válido\n", STDERR_FILENO);
+				break ;
+			}
+			args++;
+		}
+	}
 }

--- a/utils/args.c
+++ b/utils/args.c
@@ -1,5 +1,24 @@
 #include "minishell.h"
 
+char	**get_first_non_empty_arg_pos(char **args)
+{
+	char	*trim;
+
+	while (*args)
+	{
+		trim = ft_strtrim(*args, " \t");
+		if (ft_strlen(trim))
+		{
+			free (trim);
+			return (args);
+		}
+		if (trim)
+			free(trim);
+		args++;
+	}
+	return (0);
+}
+
 char	*get_first_non_empty_arg(char **args)
 {
 	char	*trim;

--- a/utils/ft_array_add.c
+++ b/utils/ft_array_add.c
@@ -12,6 +12,20 @@
 
 #include "minishell.h"
 
+int	ft_array_delete_pos(char ***array, int *array_len, int pos)
+{
+	char	**array_dup;
+
+	if (!array || !(*array))
+		return (0);
+	array_dup = ft_array_dup_without(*array, *array_len, *(*array + pos));
+	free(*(*array + pos));
+	free(*array);
+	*array = array_dup;
+	(*array_len)--;
+	return (1);
+}
+
 int	ft_array_add(char ***array, int *array_len, char *value)
 {
 	char		**aux;

--- a/utils/ft_expand_process_cmd.c
+++ b/utils/ft_expand_process_cmd.c
@@ -61,7 +61,7 @@ static void	process_tilde_expansion(t_expand_dollar *d)
 	}
 }
 
-static char	*expand(t_abs_struct *base, char *cmd)
+char	*expand(t_abs_struct *base, char *cmd)
 {
 	t_expand_dollar	d;
 

--- a/utils/ft_split.c
+++ b/utils/ft_split.c
@@ -47,6 +47,34 @@ int	len_of_word(const char *str, char c)
 	return (word);
 }
 
+char	**ft_split_key_value_pair(char const *s, char c)
+{
+	char	**key_value;
+	int		len;
+
+	if (!s || !ft_strchr(s, c))
+		return (0);
+	key_value = ft_calloc(3, sizeof(char *));
+	if (!key_value)
+		return (0);
+	len = ft_strchr(s, c) - s;
+	*key_value = ft_calloc(len + 1, sizeof(char));
+	if (!(*key_value))
+	{
+		ft_array_release(key_value);
+		return (0);
+	}
+	*(key_value + 1) = ft_calloc(ft_strlen(s) - len, sizeof(char));
+	if (!*(key_value + 1))
+	{
+		ft_array_release(key_value);
+		return (0);
+	}
+	ft_memcpy(*key_value, s, len);
+	ft_memcpy(*(key_value + 1), s + len + 1, ft_strlen(s) - len - 1);
+	return (key_value);
+}
+
 char	**ft_split(char const *s, char c)
 {
 	char	**str;

--- a/utils/ft_strchr.c
+++ b/utils/ft_strchr.c
@@ -46,3 +46,16 @@ char	*ft_strstr(const char *s, char *tgt)
 		return ((char *)s);
 	return (0);
 }
+
+char	**ft_strstr_in_array(const char **array, char *tgt)
+{
+	if (!array)
+		return (0);
+	while (*array)
+	{
+		if (ft_strstr(*array, tgt))
+			return ((char **)array);
+		array ++;
+	}
+	return (0);
+}


### PR DESCRIPTION
Ajustado el comando export para que no borre la variable con el comando export HOME

Además ajustado a la implementación de bash que permite establecer n variables

No funciona igual que bash cuando se trata de expansión de variables
